### PR TITLE
Remove unused background disclosure auto-prompt from home page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: ["main"]
   pull_request:
-    branches: [ '*' ]
+    branches: ["*"]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Verify Flutter installation
         run: flutter --version
@@ -34,17 +34,17 @@ jobs:
           if [ -f coverage/lcov.info ]; then
             echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            
+
             # Parse and display coverage using Python script (more accurate)
             if [ -f scripts/parse_coverage.py ]; then
               # Run Python script and capture output
               python_output=$(python3 scripts/parse_coverage.py 2>&1)
-              
+
               # Extract values from Python output (format: "Overall Coverage: 51.5%")
               overall_coverage=$(echo "$python_output" | grep "Overall Coverage:" | sed 's/Overall Coverage: //')
               total_lines=$(echo "$python_output" | grep "Total Lines:" | sed 's/Total Lines: //')
               hit_lines=$(echo "$python_output" | grep "Hit Lines:" | sed 's/Hit Lines: //')
-              
+
               # Write to GitHub step summary
               echo "### Overall Coverage: ${overall_coverage}" >> $GITHUB_STEP_SUMMARY
               echo "- **Total Lines**: ${total_lines}" >> $GITHUB_STEP_SUMMARY
@@ -54,7 +54,7 @@ jobs:
               echo '```' >> $GITHUB_STEP_SUMMARY
               echo "$python_output" | grep -A 1000 "File Coverage:" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
-              
+
               # Display in console (use Python script output directly)
               echo "=== Coverage Summary ==="
               echo "$python_output"

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -34,10 +34,6 @@ class HomePage extends StatelessWidget {
             );
             controller.clearError();
           }
-          if (context.mounted &&
-              controller.consumeBackgroundDisclosurePrompt()) {
-            showBackgroundLocationDisclosure(context);
-          }
         });
 
         final viewPadding = MediaQuery.viewPaddingOf(context);

--- a/lib/ui/qr_scanner_page.dart
+++ b/lib/ui/qr_scanner_page.dart
@@ -20,10 +20,22 @@ class QrScannerPage extends StatefulWidget {
     super.key,
     this.permissionCoordinator,
     this.scannerOverride,
+    this.scannerBuilder,
+    this.startScannerOverride,
+    this.stopScannerOverride,
+    this.disposeScannerOverride,
   });
 
   final PermissionCoordinator? permissionCoordinator;
   final Widget? scannerOverride;
+  final Widget Function(
+    BuildContext context,
+    MobileScannerController? controller,
+    Future<void> Function(BarcodeCapture capture) onDetect,
+  )? scannerBuilder;
+  final Future<void> Function()? startScannerOverride;
+  final Future<void> Function()? stopScannerOverride;
+  final VoidCallback? disposeScannerOverride;
 
   @override
   State<QrScannerPage> createState() => _QrScannerPageState();
@@ -61,6 +73,7 @@ class _QrScannerPageState extends State<QrScannerPage>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    widget.disposeScannerOverride?.call();
     _controller?.dispose();
     super.dispose();
   }
@@ -84,7 +97,7 @@ class _QrScannerPageState extends State<QrScannerPage>
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
       case AppLifecycleState.detached:
-        unawaited(_controller?.stop() ?? Future<void>.value());
+        unawaited(_stopScanner());
     }
   }
 
@@ -137,7 +150,7 @@ class _QrScannerPageState extends State<QrScannerPage>
     _isStartingScanner = true;
 
     try {
-      await _controller!.start();
+      await _startScannerController();
       if (!mounted) {
         return;
       }
@@ -184,6 +197,16 @@ class _QrScannerPageState extends State<QrScannerPage>
   Future<void> _openSettingsAndRefresh() async {
     _awaitingSettingsReturn = true;
     await _permissionCoordinator.openSettings();
+  }
+
+  Future<void> _startScannerController() {
+    return widget.startScannerOverride?.call() ?? _controller!.start();
+  }
+
+  Future<void> _stopScanner() {
+    return widget.stopScannerOverride?.call() ??
+        _controller?.stop() ??
+        Future<void>.value();
   }
 
   Future<void> _handleBarcode(BarcodeCapture capture) async {
@@ -265,14 +288,16 @@ class _QrScannerPageState extends State<QrScannerPage>
       body: Stack(
         children: [
           Positioned.fill(
-            child: _usesRealScanner
-                ? (_controller == null
-                    ? const ColoredBox(color: Colors.black)
-                    : MobileScanner(
-                        controller: _controller!,
-                        onDetect: _handleBarcode,
-                      ))
-                : (widget.scannerOverride ?? const SizedBox.shrink()),
+            child: widget.scannerBuilder != null
+                ? widget.scannerBuilder!(context, _controller, _handleBarcode)
+                : _usesRealScanner
+                    ? (_controller == null
+                        ? const ColoredBox(color: Colors.black)
+                        : MobileScanner(
+                            controller: _controller!,
+                            onDetect: _handleBarcode,
+                          ))
+                    : (widget.scannerOverride ?? const SizedBox.shrink()),
           ),
           if (_scannerState != _QrScannerState.ready)
             Positioned.fill(

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -226,6 +226,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       ListTile(
+                        key: const Key('privacyPolicyTile'),
                         contentPadding: EdgeInsets.zero,
                         leading: const Icon(Icons.privacy_tip_outlined),
                         title: const Text('Privacy Policy'),
@@ -237,6 +238,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
+                        key: const Key('innerBufferField'),
                         controller: _innerBufferController,
                         decoration: InputDecoration(
                           labelText: '反応距離 (Inner buffer)',
@@ -266,6 +268,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
+                        key: const Key('pollingIntervalField'),
                         controller: _pollingIntervalController,
                         decoration: InputDecoration(
                           labelText: 'ポーリング間隔 (GPS間隔)',
@@ -291,6 +294,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
+                        key: const Key('gpsAccuracyField'),
                         controller: _gpsAccuracyThresholdController,
                         decoration: InputDecoration(
                           labelText: 'GPS精度閾値',
@@ -320,6 +324,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
+                        key: const Key('leaveConfirmSamplesField'),
                         controller: _leaveConfirmSamplesController,
                         decoration: InputDecoration(
                           labelText: '離脱確定サンプル数',
@@ -345,6 +350,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
+                        key: const Key('leaveConfirmSecondsField'),
                         controller: _leaveConfirmSecondsController,
                         decoration: InputDecoration(
                           labelText: '離脱確定秒数',
@@ -397,6 +403,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 24),
                       ElevatedButton(
+                        key: const Key('saveSettingsButton'),
                         onPressed: _isSaving ? null : _applySettings,
                         style: ElevatedButton.styleFrom(
                           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -425,6 +432,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       const SizedBox(height: 16),
                       ElevatedButton(
+                        key: const Key('exportLogsButton'),
                         onPressed: () async {
                           final export = await controller.logger.exportJsonl();
                           if (!context.mounted) return;

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -92,6 +92,211 @@ void main() {
       expect(controller.lastErrorMessage, isNull);
     });
 
+    test('startMonitoring sets blocked error when permission is missing',
+        () async {
+      final coordinator = _TrackingPermissionCoordinator(
+        refreshState: const MonitoringPermissionState(
+          notificationStatus: PermissionStatus.granted,
+          locationWhenInUseStatus: PermissionStatus.granted,
+          locationAlwaysStatus: PermissionStatus.denied,
+          locationServicesEnabled: true,
+        ),
+      );
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: FakeFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: coordinator,
+      );
+
+      controller.debugSeed(
+        config: _testConfig(),
+        geoJson: _squareModel(),
+        permissionState: const MonitoringPermissionState(
+          notificationStatus: PermissionStatus.granted,
+          locationWhenInUseStatus: PermissionStatus.granted,
+          locationAlwaysStatus: PermissionStatus.denied,
+          locationServicesEnabled: true,
+        ),
+      );
+
+      await controller.startMonitoring();
+
+      expect(controller.lastErrorMessage, contains('常に許可'));
+      expect(controller.logs.first.level.name, 'warning');
+    });
+
+    test('clearError removes existing error and notifies listeners', () async {
+      final controller = _buildController();
+      controller.debugSeed(
+        snapshot: StateSnapshot(
+          status: LocationStateStatus.outer,
+          timestamp: DateTime.now(),
+          geoJsonLoaded: true,
+        ),
+      );
+      await controller.reloadGeoJsonFromQr('invalid:qr');
+
+      expect(controller.lastErrorMessage, isNotNull);
+
+      controller.clearError();
+
+      expect(controller.lastErrorMessage, isNull);
+    });
+
+    test('startMonitoring surfaces location service start errors', () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: _FailingStartLocationService(),
+        fileManager: FakeFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: _GrantedPermissionCoordinator(),
+      );
+      controller.debugSeed(
+        config: _testConfig(),
+        geoJson: _squareModel(),
+        permissionState: _grantedMonitoringPermissionState(),
+      );
+
+      await controller.startMonitoring();
+
+      expect(controller.lastErrorMessage, 'boom');
+      expect(controller.logs.first.level.name, 'error');
+    });
+
+    test('updateConfig saves config and restarts active monitoring', () async {
+      final config = _testConfig();
+      final stateMachine = StateMachine(config: config);
+      final locationService = FakeLocationService();
+      final fileManager = _SavingFileManager(config: config);
+      final controller = AppController(
+        stateMachine: stateMachine,
+        locationService: locationService,
+        fileManager: fileManager,
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: _GrantedPermissionCoordinator(),
+      );
+      controller.debugSeed(
+        config: config,
+        geoJson: _squareModel(),
+        permissionState: _grantedMonitoringPermissionState(),
+      );
+      await controller.startMonitoring();
+
+      final updated = AppConfig(
+        innerBufferM: 12,
+        leaveConfirmSamples: 2,
+        leaveConfirmSeconds: 5,
+        gpsAccuracyBadMeters: 20,
+        sampleIntervalS: const {'fast': 2},
+        sampleDistanceM: const {'fast': 1},
+        screenWakeOnLeave: false,
+        alarmVolume: 0.8,
+      );
+
+      await controller.updateConfig(updated);
+
+      expect(fileManager.savedConfig, isNotNull);
+      expect(fileManager.savedConfig!.innerBufferM, 12);
+      expect(locationService.startCount, 2);
+      expect(locationService.stopCount, 1);
+      expect(controller.config!.alarmVolume, 0.8);
+    });
+
+    test('refreshMonitoringPermissionState updates permission state',
+        () async {
+      final coordinator = _TrackingPermissionCoordinator(
+        refreshState: const MonitoringPermissionState(
+          notificationStatus: PermissionStatus.granted,
+          locationWhenInUseStatus: PermissionStatus.granted,
+          locationAlwaysStatus: PermissionStatus.denied,
+          locationServicesEnabled: true,
+        ),
+      );
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: FakeFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: coordinator,
+      );
+
+      await controller.refreshMonitoringPermissionState();
+
+      expect(controller.monitoringPermissionState.locationAlwaysGranted, isFalse);
+      expect(coordinator.refreshCount, 1);
+    });
+
+    test('requestNotificationPermission updates permission state', () async {
+      final coordinator = _TrackingPermissionCoordinator(
+        notificationState: const MonitoringPermissionState(
+          notificationStatus: PermissionStatus.granted,
+          locationWhenInUseStatus: PermissionStatus.granted,
+          locationAlwaysStatus: PermissionStatus.granted,
+          locationServicesEnabled: true,
+        ),
+      );
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: FakeFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: coordinator,
+      );
+
+      await controller.requestNotificationPermission();
+
+      expect(coordinator.requestNotificationCount, 1);
+      expect(controller.monitoringPermissionState.notificationGranted, isTrue);
+    });
+
+    test('completeMonitoringPermissionSetup keeps blocked error when denied',
+        () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: FakeFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        permissionCoordinator: _TrackingPermissionCoordinator(
+          completeState: const MonitoringPermissionState(
+            notificationStatus: PermissionStatus.granted,
+            locationWhenInUseStatus: PermissionStatus.granted,
+            locationAlwaysStatus: PermissionStatus.denied,
+            locationServicesEnabled: true,
+          ),
+        ),
+      );
+
+      await controller.completeMonitoringPermissionSetup();
+
+      expect(controller.lastErrorMessage, contains('常に許可'));
+    });
+
     test('loading new GeoJSON resets to init and stops alarm', () async {
       final config = _testConfig();
       final stateMachine = StateMachine(config: config);
@@ -464,6 +669,63 @@ void main() {
       expect(controller.geoJsonLoaded, isFalse);
     });
 
+    test('reloadGeoJsonFromPicker handles parse errors gracefully', () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _InvalidGeoJsonFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+      );
+
+      await controller.reloadGeoJsonFromPicker();
+
+      expect(controller.lastErrorMessage, contains('Failed to parse GeoJSON'));
+    });
+
+    test('reloadGeoJsonFromPicker ignores user cancellation', () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _ThrowingGeoJsonFileManager(
+          config: _testConfig(),
+          error: Exception('user cancel'),
+        ),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+      );
+
+      await controller.reloadGeoJsonFromPicker();
+
+      expect(controller.lastErrorMessage, isNull);
+    });
+
+    test('reloadGeoJsonFromPicker reports unexpected file errors', () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _ThrowingGeoJsonFileManager(
+          config: _testConfig(),
+          error: Exception('disk failure'),
+        ),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+      );
+
+      await controller.reloadGeoJsonFromPicker();
+
+      expect(controller.lastErrorMessage, contains('Unable to open file'));
+    });
+
     test('reloadGeoJsonFromQr handles decode errors gracefully', () async {
       final config = _testConfig();
       final stateMachine = StateMachine(config: config);
@@ -737,6 +999,44 @@ class FakeFileManager extends FileManager {
   }
 }
 
+class _SavingFileManager extends FakeFileManager {
+  _SavingFileManager({required super.config});
+
+  AppConfig? savedConfig;
+
+  @override
+  Future<void> saveConfig(AppConfig config) async {
+    savedConfig = config;
+  }
+}
+
+class _InvalidGeoJsonFileManager extends FakeFileManager {
+  _InvalidGeoJsonFileManager({required super.config});
+
+  @override
+  Future<XFile?> pickGeoJsonFile() async {
+    return XFile.fromData(
+      utf8.encode('not-json'),
+      name: 'broken.geojson',
+      mimeType: 'application/geo+json',
+    );
+  }
+}
+
+class _ThrowingGeoJsonFileManager extends FakeFileManager {
+  _ThrowingGeoJsonFileManager({
+    required super.config,
+    required this.error,
+  });
+
+  final Object error;
+
+  @override
+  Future<XFile?> pickGeoJsonFile() async {
+    throw error;
+  }
+}
+
 class FakeEventLogger extends EventLogger {
   final List<StateSnapshot> stateChanges = <StateSnapshot>[];
 
@@ -760,6 +1060,8 @@ class FakeLocationService implements LocationService {
 
   bool started = false;
   bool stopped = false;
+  int startCount = 0;
+  int stopCount = 0;
 
   @override
   Stream<LocationFix> get stream => _controller.stream;
@@ -767,17 +1069,35 @@ class FakeLocationService implements LocationService {
   @override
   Future<LocationServiceStartResult> start(AppConfig config) async {
     started = true;
+    startCount += 1;
     return const LocationServiceStartResult.started();
   }
 
   @override
   Future<void> stop() async {
     stopped = true;
+    stopCount += 1;
   }
 
   void add(LocationFix fix) {
     _controller.add(fix);
   }
+}
+
+class _FailingStartLocationService implements LocationService {
+  @override
+  Stream<LocationFix> get stream => const Stream.empty();
+
+  @override
+  Future<LocationServiceStartResult> start(AppConfig config) async {
+    return const LocationServiceStartResult(
+      status: LocationServiceStartStatus.error,
+      message: 'boom',
+    );
+  }
+
+  @override
+  Future<void> stop() async {}
 }
 
 Future<void> _ensureBrotliCli() async {

--- a/test/app_lifecycle_test.dart
+++ b/test/app_lifecycle_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/app_controller.dart';
+import 'package:argus/main.dart';
+import 'package:argus/platform/notifier.dart';
+import 'package:argus/platform/permission_coordinator.dart';
+import 'package:argus/state_machine/state_machine.dart';
+
+import 'support/notifier_fakes.dart';
+import 'support/test_doubles.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ArgusApp refreshes permissions on resume', (tester) async {
+    final controller = _LifecycleController();
+
+    await tester.pumpWidget(ArgusApp(controller: controller));
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(controller.refreshCount, 1);
+  });
+
+  testWidgets('ArgusApp handles app termination on detach', (tester) async {
+    final controller = _LifecycleController();
+
+    await tester.pumpWidget(ArgusApp(controller: controller));
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.detached);
+    await tester.pump();
+
+    expect(controller.terminationCount, 1);
+  });
+
+  testWidgets('ArgusApp removes lifecycle observer on dispose', (tester) async {
+    final controller = _LifecycleController();
+
+    await tester.pumpWidget(ArgusApp(controller: controller));
+    await tester.pumpWidget(const SizedBox.shrink());
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(controller.refreshCount, 0);
+  });
+}
+
+class _LifecycleController extends AppController {
+  _LifecycleController()
+      : super(
+          stateMachine: StateMachine(config: createTestConfig()),
+          locationService: FakeLocationService(),
+          fileManager: FakeFileManager(config: createTestConfig()),
+          logger: FakeEventLogger(),
+          notifier: Notifier(
+            notificationsClient: FakeLocalNotificationsClient(),
+            alarmPlayer: FakeAlarmPlayer(),
+          ),
+          permissionCoordinator: PermissionCoordinator(),
+        ) {
+    debugSeed(config: createTestConfig());
+  }
+
+  int refreshCount = 0;
+  int terminationCount = 0;
+
+  @override
+  Future<void> refreshMonitoringPermissionState() async {
+    refreshCount += 1;
+  }
+
+  @override
+  Future<void> handleAppTermination() async {
+    terminationCount += 1;
+  }
+}

--- a/test/app_links_test.dart
+++ b/test/app_links_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/app_links.dart';
+
+import 'support/platform_mocks.dart';
+
+void main() {
+  tearDown(() async {
+    await clearUrlLauncherMock();
+  });
+
+  test('openPrivacyPolicy launches external privacy policy URL', () async {
+    final calls = await mockUrlLauncher(launchResult: true);
+
+    final launched = await openPrivacyPolicy();
+
+    expect(launched, isTrue);
+    expect(calls, isNotEmpty);
+    expect(
+      calls.any((call) =>
+          call.method.toLowerCase().contains('launch') &&
+          call.arguments.toString().contains(privacyPolicyUrl)),
+      isTrue,
+    );
+  });
+}

--- a/test/io/config_test.dart
+++ b/test/io/config_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/io/config.dart';
+
+import '../support/platform_mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await mockDefaultConfigAsset();
+  });
+
+  tearDownAll(() async {
+    await clearDefaultConfigAssetMock();
+  });
+
+  test('fromJson parses values and toJson preserves fields', () {
+    final config = AppConfig.fromJson(<String, dynamic>{
+      'inner_buffer_m': 12.5,
+      'leave_confirm_samples': 4,
+      'leave_confirm_seconds': 8,
+      'gps_accuracy_bad_m': 33.3,
+      'sample_interval_s': <String, dynamic>{'fast': 2, 'slow': 5},
+      'sample_distance_m': <String, dynamic>{'fast': 10, 'slow': 20},
+      'screen_wake_on_leave': true,
+      'alarm_volume': 0.8,
+    });
+
+    expect(config.innerBufferM, 12.5);
+    expect(config.leaveConfirmSamples, 4);
+    expect(config.leaveConfirmSeconds, 8);
+    expect(config.gpsAccuracyBadMeters, 33.3);
+    expect(config.sampleIntervalS, {'fast': 2, 'slow': 5});
+    expect(config.sampleDistanceM, {'fast': 10, 'slow': 20});
+    expect(config.screenWakeOnLeave, isTrue);
+    expect(config.alarmVolume, 0.8);
+    expect(config.toJson(), <String, dynamic>{
+      'inner_buffer_m': 12.5,
+      'leave_confirm_samples': 4,
+      'leave_confirm_seconds': 8,
+      'gps_accuracy_bad_m': 33.3,
+      'sample_interval_s': <String, int>{'fast': 2, 'slow': 5},
+      'sample_distance_m': <String, int>{'fast': 10, 'slow': 20},
+      'screen_wake_on_leave': true,
+      'alarm_volume': 0.8,
+    });
+  });
+
+  test('fromJson falls back to default wake and volume values', () {
+    final config = AppConfig.fromJson(<String, dynamic>{
+      'inner_buffer_m': 5,
+      'leave_confirm_samples': 1,
+      'leave_confirm_seconds': 2,
+      'gps_accuracy_bad_m': 10,
+      'sample_interval_s': <String, dynamic>{'fast': 3},
+      'sample_distance_m': <String, dynamic>{'fast': 15},
+    });
+
+    expect(config.screenWakeOnLeave, isFalse);
+    expect(config.alarmVolume, 0.5);
+  });
+
+  test('loadDefault reads bundled config asset', () async {
+    final config = await AppConfig.loadDefault();
+
+    expect(config.innerBufferM, greaterThan(0));
+    expect(config.leaveConfirmSamples, greaterThan(0));
+    expect(config.leaveConfirmSeconds, greaterThan(0));
+    expect(config.sampleIntervalS, isNotEmpty);
+    expect(config.sampleDistanceM, isNotEmpty);
+  });
+}

--- a/test/io/file_manager_test.dart
+++ b/test/io/file_manager_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/io/config.dart';
+import 'package:argus/io/file_manager.dart';
+
+void main() {
+  late Directory tempDir;
+  late AppConfig defaultConfig;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('argus_file_manager_test_');
+    defaultConfig = AppConfig(
+      innerBufferM: 5,
+      leaveConfirmSamples: 2,
+      leaveConfirmSeconds: 4,
+      gpsAccuracyBadMeters: 30,
+      sampleIntervalS: const {'fast': 3},
+      sampleDistanceM: const {'fast': 15},
+      screenWakeOnLeave: false,
+      alarmVolume: 0.4,
+    );
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('pickGeoJsonFile passes expected file filter', () async {
+    List<XTypeGroup>? capturedGroups;
+    final manager = FileManager(
+      filePicker: ({acceptedTypeGroups}) async {
+        capturedGroups = acceptedTypeGroups;
+        return null;
+      },
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+
+    await manager.pickGeoJsonFile();
+
+    expect(capturedGroups, isNotNull);
+    expect(capturedGroups, hasLength(1));
+    expect(capturedGroups!.single.label, 'GeoJSON files');
+    expect(capturedGroups!.single.extensions, ['geojson', 'json', 'bin']);
+  });
+
+  test('getConfigFile creates config file with default config when missing',
+      () async {
+    final manager = FileManager(
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+
+    final file = await manager.getConfigFile();
+
+    expect(await file.exists(), isTrue);
+    final decoded =
+        jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+    expect(decoded['inner_buffer_m'], 5);
+    expect(decoded['alarm_volume'], 0.4);
+  });
+
+  test('saveConfig persists JSON to config file', () async {
+    final manager = FileManager(
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+    final updated = AppConfig(
+      innerBufferM: 12,
+      leaveConfirmSamples: 3,
+      leaveConfirmSeconds: 6,
+      gpsAccuracyBadMeters: 22,
+      sampleIntervalS: const {'fast': 1},
+      sampleDistanceM: const {'fast': 5},
+      screenWakeOnLeave: true,
+      alarmVolume: 0.9,
+    );
+
+    await manager.saveConfig(updated);
+
+    final file = File('${tempDir.path}/config.json');
+    final decoded =
+        jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+    expect(decoded['inner_buffer_m'], 12.0);
+    expect(decoded['screen_wake_on_leave'], isTrue);
+    expect(decoded['alarm_volume'], 0.9);
+  });
+
+  test('readConfig returns parsed config when file is valid', () async {
+    final file = File('${tempDir.path}/config.json');
+    await file.writeAsString(jsonEncode(defaultConfig.toJson()));
+    final manager = FileManager(
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => AppConfig(
+        innerBufferM: 1,
+        leaveConfirmSamples: 1,
+        leaveConfirmSeconds: 1,
+        gpsAccuracyBadMeters: 1,
+        sampleIntervalS: const {'fast': 1},
+        sampleDistanceM: const {'fast': 1},
+        screenWakeOnLeave: false,
+        alarmVolume: 0.1,
+      ),
+    );
+
+    final config = await manager.readConfig();
+
+    expect(config.innerBufferM, defaultConfig.innerBufferM);
+    expect(config.leaveConfirmSamples, defaultConfig.leaveConfirmSamples);
+  });
+
+  test('readConfig falls back to default config on invalid JSON', () async {
+    final file = File('${tempDir.path}/config.json');
+    await file.writeAsString('{invalid');
+    final manager = FileManager(
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+
+    final config = await manager.readConfig();
+
+    expect(config.innerBufferM, defaultConfig.innerBufferM);
+    expect(config.alarmVolume, defaultConfig.alarmVolume);
+  });
+
+  test('openLogFile creates log file when missing', () async {
+    final manager = FileManager(
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+
+    final file = await manager.openLogFile();
+
+    expect(file.path, '${tempDir.path}/argus.log');
+    expect(await file.exists(), isTrue);
+  });
+}

--- a/test/io/log_entry_test.dart
+++ b/test/io/log_entry_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/io/log_entry.dart';
+
+void main() {
+  test('debug factory sets debug level and provided timestamp', () {
+    final timestamp = DateTime.utc(2024, 1, 1, 12, 0);
+    final entry = AppLogEntry.debug(
+      tag: 'GPS',
+      message: 'debug',
+      timestamp: timestamp,
+    );
+
+    expect(entry.level, AppLogLevel.debug);
+    expect(entry.tag, 'GPS');
+    expect(entry.message, 'debug');
+    expect(entry.timestamp, timestamp);
+  });
+
+  test('info factory defaults timestamp when omitted', () {
+    final before = DateTime.now();
+    final entry = AppLogEntry.info(tag: 'APP', message: 'info');
+    final after = DateTime.now();
+
+    expect(entry.level, AppLogLevel.info);
+    expect(
+      entry.timestamp.isAfter(before.subtract(const Duration(seconds: 1))),
+      isTrue,
+    );
+    expect(
+      entry.timestamp.isBefore(after.add(const Duration(seconds: 1))),
+      isTrue,
+    );
+  });
+
+  test('warning and error factories set matching levels', () {
+    final warning = AppLogEntry.warning(tag: 'APP', message: 'warn');
+    final error = AppLogEntry.error(tag: 'APP', message: 'error');
+
+    expect(warning.level, AppLogLevel.warning);
+    expect(error.level, AppLogLevel.error);
+  });
+}

--- a/test/platform/location_service_test.dart
+++ b/test/platform/location_service_test.dart
@@ -1,47 +1,63 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:argus/io/config.dart';
 import 'package:argus/platform/location_service.dart';
 
-import '../support/test_doubles.dart' as test_doubles;
-
 void main() {
-  group('Location service test doubles', () {
-    test('LocationFix stores provided values', () {
-      final fix = LocationFix(
-        latitude: 35.0,
-        longitude: 139.0,
-        accuracyMeters: 4.5,
-        batteryPercent: 90,
-        timestamp: DateTime.utc(2024, 1, 1),
-      );
+  final config = AppConfig(
+    innerBufferM: 5,
+    leaveConfirmSamples: 1,
+    leaveConfirmSeconds: 1,
+    gpsAccuracyBadMeters: 10,
+    sampleIntervalS: const {'fast': 3},
+    sampleDistanceM: const {'fast': 5},
+    screenWakeOnLeave: false,
+    alarmVolume: 0.5,
+  );
 
-      expect(fix.latitude, 35.0);
-      expect(fix.longitude, 139.0);
-      expect(fix.accuracyMeters, 4.5);
-      expect(fix.batteryPercent, 90);
-    });
+  test('LocationFix stores provided values', () {
+    final timestamp = DateTime.utc(2024, 1, 1);
+    const accuracy = 4.2;
+    const battery = 0.75;
+    final fix = LocationFix(
+      latitude: 35.0,
+      longitude: 139.0,
+      timestamp: timestamp,
+      accuracyMeters: accuracy,
+      batteryPercent: battery,
+    );
 
-    test('FakeLocationService emits updates and tracks lifecycle', () async {
-      final service = test_doubles.FakeLocationService();
-      final config = test_doubles.createTestConfig();
-      final completer = Completer<LocationFix>();
-      service.stream.listen(completer.complete);
+    expect(fix.latitude, 35.0);
+    expect(fix.longitude, 139.0);
+    expect(fix.timestamp, timestamp);
+    expect(fix.accuracyMeters, accuracy);
+    expect(fix.batteryPercent, battery);
+  });
 
-      await service.start(config);
-      expect(service.hasStarted, isTrue);
+  test('LocationServiceStartResult.started has started status and no message',
+      () {
+    const result = LocationServiceStartResult.started();
 
-      final fix = LocationFix(
+    expect(result.status, LocationServiceStartStatus.started);
+    expect(result.message, isNull);
+  });
+
+  test('FakeLocationService emits updates and tracks lifecycle', () async {
+    final fixes = <LocationFix>[
+      LocationFix(
         latitude: 1,
         longitude: 2,
-        timestamp: DateTime.utc(2024, 1, 1, 0, 0, 1),
-      );
-      service.add(fix);
-      expect(await completer.future, fix);
+        timestamp: DateTime.utc(2024, 1, 1),
+      ),
+    ];
+    final service = FakeLocationService(Stream<LocationFix>.fromIterable(fixes));
 
-      await service.stop();
-      expect(service.hasStopped, isTrue);
-    });
+    final received = await service.stream.toList();
+    final result = await service.start(config);
+    await service.stop();
+
+    expect(received, hasLength(1));
+    expect(received.single.latitude, 1);
+    expect(result.status, LocationServiceStartStatus.started);
   });
 }

--- a/test/platform/notifier_test.dart
+++ b/test/platform/notifier_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:argus/platform/notifier.dart';
+import 'package:argus/state_machine/state.dart';
 import '../support/notifier_fakes.dart';
 
 void main() {
@@ -124,6 +125,38 @@ void main() {
       expect(notifications.cancelledIds, [1001]);
       expect(alarm.stopCount, 1);
       expect(vibration.stopCount, 1);
+    });
+
+    test('initialize is idempotent and updates badge state', () async {
+      final notifications = FakeLocalNotificationsClient();
+      final notifier = Notifier(
+        notificationsClient: notifications,
+        alarmPlayer: FakeAlarmPlayer(),
+        vibrationPlayer: FakeVibrationPlayer(),
+      );
+
+      await notifier.initialize();
+      await notifier.initialize();
+      await notifier.updateBadge(LocationStateStatus.near);
+
+      expect(notifications.initializeCount, 1);
+      expect(notifications.ensureChannelCount, 1);
+      expect(notifier.badgeState.value, LocationStateStatus.near);
+    });
+
+    test('stopAlarm is a no-op when alarm is not active', () async {
+      final alarm = FakeAlarmPlayer();
+      final vibration = FakeVibrationPlayer();
+      final notifier = Notifier(
+        notificationsClient: FakeLocalNotificationsClient(),
+        alarmPlayer: alarm,
+        vibrationPlayer: vibration,
+      );
+
+      await notifier.stopAlarm();
+
+      expect(alarm.stopCount, 0);
+      expect(vibration.stopCount, 0);
     });
   });
 }

--- a/test/platform/permission_coordinator_test.dart
+++ b/test/platform/permission_coordinator_test.dart
@@ -4,6 +4,50 @@ import 'package:permission_handler/permission_handler.dart';
 
 void main() {
   group('PermissionCoordinator', () {
+    test('monitoring permission state exposes summaries and blocked messages',
+        () {
+      const deniedState = MonitoringPermissionState(
+        notificationStatus: PermissionStatus.denied,
+        locationWhenInUseStatus: PermissionStatus.denied,
+        locationAlwaysStatus: PermissionStatus.denied,
+        locationServicesEnabled: false,
+      );
+      const readyState = MonitoringPermissionState(
+        notificationStatus: PermissionStatus.granted,
+        locationWhenInUseStatus: PermissionStatus.granted,
+        locationAlwaysStatus: PermissionStatus.granted,
+        locationServicesEnabled: true,
+      );
+
+      expect(deniedState.canStartMonitoring, isFalse);
+      expect(deniedState.monitoringBlockedMessage, contains('位置情報サービス'));
+      expect(deniedState.setupSummary, contains('位置情報サービス'));
+      expect(readyState.notificationGranted, isTrue);
+      expect(readyState.locationWhenInUseGranted, isTrue);
+      expect(readyState.locationAlwaysGranted, isTrue);
+      expect(readyState.canStartMonitoring, isTrue);
+      expect(readyState.setupSummary, '監視を開始できる状態です。');
+      expect(
+        readyState.copyWith(locationAlwaysStatus: PermissionStatus.denied)
+            .locationAlwaysGranted,
+        isFalse,
+      );
+    });
+
+    test('camera permission state exposes guidance', () {
+      const granted =
+          CameraPermissionState(status: PermissionStatus.provisional);
+      const denied =
+          CameraPermissionState(status: PermissionStatus.permanentlyDenied);
+      const normalDenied = CameraPermissionState(status: PermissionStatus.denied);
+
+      expect(granted.isGranted, isTrue);
+      expect(granted.message, 'カメラを使用できます。');
+      expect(denied.requiresManualSettings, isTrue);
+      expect(denied.message, contains('アプリ設定'));
+      expect(normalDenied.message, contains('QR'));
+    });
+
     test('refreshMonitoringPermissionState does not request permissions',
         () async {
       final gateway = _FakePermissionGateway(
@@ -81,6 +125,116 @@ void main() {
       expect(openSettingsCount, 1);
       expect(state.locationAlwaysGranted, isFalse);
     });
+
+    test('requestNotificationPermission requests notification and refreshes',
+        () async {
+      final gateway = _FakePermissionGateway(
+        notificationStatusValue: PermissionStatus.denied,
+        notificationRequestResult: PermissionStatus.granted,
+      );
+
+      final coordinator = PermissionCoordinator(
+        gateway: gateway,
+        openSettings: () async => true,
+        openLocationSettings: () async => true,
+        locationServicesEnabled: () async => true,
+      );
+
+      final state = await coordinator.requestNotificationPermission();
+
+      expect(gateway.requestNotificationCount, 1);
+      expect(state.notificationGranted, isTrue);
+    });
+
+    test('completeMonitoringSetup opens location settings when services off',
+        () async {
+      final gateway = _FakePermissionGateway();
+      var openLocationSettingsCount = 0;
+
+      final coordinator = PermissionCoordinator(
+        gateway: gateway,
+        openSettings: () async => true,
+        openLocationSettings: () async {
+          openLocationSettingsCount += 1;
+          return true;
+        },
+        locationServicesEnabled: () async => false,
+      );
+
+      final state = await coordinator.completeMonitoringSetup();
+
+      expect(openLocationSettingsCount, 1);
+      expect(state.locationServicesEnabled, isFalse);
+    });
+
+    test('completeMonitoringSetup opens app settings when foreground denied',
+        () async {
+      final gateway = _FakePermissionGateway(
+        locationWhenInUseStatusValue: PermissionStatus.denied,
+        locationWhenInUseRequestResult: PermissionStatus.restricted,
+      );
+      var openSettingsCount = 0;
+
+      final coordinator = PermissionCoordinator(
+        gateway: gateway,
+        openSettings: () async {
+          openSettingsCount += 1;
+          return true;
+        },
+        openLocationSettings: () async => true,
+        locationServicesEnabled: () async => true,
+      );
+
+      final state = await coordinator.completeMonitoringSetup();
+
+      expect(gateway.requestLocationWhenInUseCount, 1);
+      expect(openSettingsCount, 1);
+      expect(state.locationWhenInUseGranted, isFalse);
+    });
+
+    test('ensureCameraPermission requests once and can open settings',
+        () async {
+      final gateway = _FakePermissionGateway(
+        cameraStatusValue: PermissionStatus.denied,
+        cameraRequestResult: PermissionStatus.restricted,
+      );
+      var openSettingsCount = 0;
+
+      final coordinator = PermissionCoordinator(
+        gateway: gateway,
+        openSettings: () async {
+          openSettingsCount += 1;
+          return true;
+        },
+        openLocationSettings: () async => true,
+        locationServicesEnabled: () async => true,
+      );
+
+      final state =
+          await coordinator.ensureCameraPermission(openSettingsIfNeeded: true);
+
+      expect(gateway.requestCameraCount, 1);
+      expect(state.requiresManualSettings, isTrue);
+      expect(openSettingsCount, 1);
+    });
+
+    test('openSettings proxies to provided callback', () async {
+      var openSettingsCount = 0;
+      final coordinator = PermissionCoordinator(
+        gateway: _FakePermissionGateway(),
+        openSettings: () async {
+          openSettingsCount += 1;
+          return true;
+        },
+        openLocationSettings: () async => true,
+        locationServicesEnabled: () async => true,
+      );
+
+      final opened = await coordinator.openSettings();
+
+      expect(opened, isTrue);
+      expect(openSettingsCount, 1);
+    });
   });
 }
 
@@ -92,6 +246,8 @@ class _FakePermissionGateway implements PermissionGateway {
     this.locationWhenInUseRequestResult = PermissionStatus.granted,
     this.locationAlwaysStatusValue = PermissionStatus.granted,
     this.locationAlwaysRequestResult = PermissionStatus.granted,
+    this.cameraStatusValue = PermissionStatus.granted,
+    this.cameraRequestResult = PermissionStatus.granted,
   });
 
   PermissionStatus notificationStatusValue;
@@ -100,13 +256,16 @@ class _FakePermissionGateway implements PermissionGateway {
   PermissionStatus locationWhenInUseRequestResult;
   PermissionStatus locationAlwaysStatusValue;
   PermissionStatus locationAlwaysRequestResult;
+  PermissionStatus cameraStatusValue;
+  PermissionStatus cameraRequestResult;
 
   int requestNotificationCount = 0;
   int requestLocationWhenInUseCount = 0;
   int requestLocationAlwaysCount = 0;
+  int requestCameraCount = 0;
 
   @override
-  Future<PermissionStatus> cameraStatus() async => PermissionStatus.granted;
+  Future<PermissionStatus> cameraStatus() async => cameraStatusValue;
 
   @override
   Future<PermissionStatus> locationAlwaysStatus() async =>
@@ -122,7 +281,9 @@ class _FakePermissionGateway implements PermissionGateway {
 
   @override
   Future<PermissionStatus> requestCamera() async {
-    return PermissionStatus.granted;
+    requestCameraCount += 1;
+    cameraStatusValue = cameraRequestResult;
+    return cameraRequestResult;
   }
 
   @override

--- a/test/qr/geojson_qr_codec_test.dart
+++ b/test/qr/geojson_qr_codec_test.dart
@@ -108,6 +108,140 @@ void main() {
       throwsA(isA<DecodeFailedException>()),
     );
   });
+
+  test('bundle getters and exception toString expose metadata', () {
+    final bundle = GeoJsonQrBundle(
+      qrTexts: const ['a', 'b'],
+      pngImages: const [],
+      minimizedGeoJson: '{}',
+      hashHex: null,
+      info: const GeoJsonInfo(type: 'FeatureCollection', featureCount: 0),
+    );
+
+    final validation = GeoJsonValidationException('bad json');
+    final compress = CompressFailedException('compress failed', 'cli');
+    final decompress = DecompressFailedException('decompress failed');
+    final payload = PayloadTooLargeException('too large');
+    final qr = QrGenerationException('render failed');
+
+    expect(bundle.chunkCount, 2);
+    expect(bundle.isSplit, isTrue);
+    expect(validation.toString(), contains('E_INVALID_GEOJSON'));
+    expect(compress.toString(), contains('cli'));
+    expect(decompress.code, 'E_DECOMPRESS_FAILED');
+    expect(payload.code, 'E_PAYLOAD_TOO_LARGE');
+    expect(qr.code, 'E_QR_GENERATION');
+  });
+
+  test('encode without hash omits hash suffix', () async {
+    final bundle = await encodeGeoJson(
+      GeoJsonQrEncodeInput(
+        geoJson: sampleGeoJson,
+        enableHash: false,
+        generatePng: false,
+      ),
+    );
+
+    expect(bundle.hashHex, isNull);
+    expect(bundle.chunkCount, 1);
+    expect(bundle.qrTexts.single, startsWith('gjb1:'));
+    expect(bundle.qrTexts.single.contains('#'), isFalse);
+  });
+
+  test('decode rejects empty input and empty gjb1 payload', () async {
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: [])),
+      throwsA(isA<UnsupportedSchemeException>()),
+    );
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjb1:'])),
+      throwsA(isA<DecodeFailedException>()),
+    );
+  });
+
+  test('minify and validate reject malformed GeoJSON structures', () {
+    expect(
+      () => minifyGeoJson('{invalid'),
+      throwsA(isA<GeoJsonValidationException>()),
+    );
+    expect(
+      () => validateGeoJsonStructure(const ['not-an-object']),
+      throwsA(isA<GeoJsonValidationException>()),
+    );
+    expect(
+      () => validateGeoJsonStructure(const {'features': []}),
+      throwsA(isA<GeoJsonValidationException>()),
+    );
+    expect(
+      () => validateGeoJsonStructure(const {'type': 'Circle'}),
+      throwsA(isA<GeoJsonValidationException>()),
+    );
+    expect(
+      () => validateGeoJsonStructure(
+        const {'type': 'FeatureCollection', 'features': 'oops'},
+      ),
+      throwsA(isA<GeoJsonValidationException>()),
+    );
+  });
+
+  test('buildGjB1pTexts rejects undersized limits', () {
+    expect(
+      () => buildGjB1pTexts('payload', maxLength: 12),
+      throwsA(isA<PayloadTooLargeException>()),
+    );
+    expect(
+      () => buildGjB1pTexts('x' * 1000, maxLength: 13),
+      throwsA(isA<PayloadTooLargeException>()),
+    );
+  });
+
+  test('decode rejects malformed gjb1p metadata and malformed hash suffix',
+      () async {
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjb1p:abc'])),
+      throwsA(isA<UnsupportedSchemeException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(
+          qrTexts: ['gjb1p:0/2:a', 'gjb1p:2/2:b'],
+        ),
+      ),
+      throwsA(isA<ChunkMismatchException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(
+          qrTexts: ['gjb1p:1/2:a', 'gjb1p:2/3:b'],
+        ),
+      ),
+      throwsA(isA<ChunkMismatchException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(
+          qrTexts: ['gjb1p:1/2:a', 'gjb1p:1/2:b'],
+        ),
+      ),
+      throwsA(isA<ChunkMismatchException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(qrTexts: ['gjb1:payload#xyz']),
+      ),
+      throwsA(isA<DecodeFailedException>()),
+    );
+  });
+
+  test('generateQrPng supports high ECC and rejects oversized payloads', () {
+    final png = generateQrPng('hello', QrErrorCorrectionLevel.high);
+
+    expect(png, isNotEmpty);
+    expect(
+      () => generateQrPng('x' * 5000, QrErrorCorrectionLevel.high),
+      throwsA(isA<PayloadTooLargeException>()),
+    );
+  });
 }
 
 Future<void> _ensureBrotliCli() async {

--- a/test/support/notifier_fakes.dart
+++ b/test/support/notifier_fakes.dart
@@ -6,12 +6,15 @@ class FakeLocalNotificationsClient implements LocalNotificationsClient {
   final List<int> shownIds = <int>[];
   final List<int> cancelledIds = <int>[];
   bool initialized = false;
+  int initializeCount = 0;
   AndroidNotificationChannel? lastChannel;
+  int ensureChannelCount = 0;
   bool requestedPermissions = false;
 
   @override
   Future<void> initialize(InitializationSettings settings) async {
     initialized = true;
+    initializeCount += 1;
   }
 
   Future<void> requestPermissions({
@@ -26,6 +29,7 @@ class FakeLocalNotificationsClient implements LocalNotificationsClient {
   @override
   Future<void> ensureAndroidChannel(AndroidNotificationChannel channel) async {
     lastChannel = channel;
+    ensureChannelCount += 1;
   }
 
   @override

--- a/test/support/platform_mocks.dart
+++ b/test/support/platform_mocks.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const MethodChannel _assetsChannel = MethodChannel('flutter/assets');
+const MethodChannel _urlLauncherChannel =
+    MethodChannel('plugins.flutter.io/url_launcher');
+
+Future<void> mockDefaultConfigAsset() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final bytes = await File('assets/config/default_config.json').readAsBytes();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', (ByteData? message) async {
+    final key = const StringCodec().decodeMessage(message);
+    if (key == 'assets/config/default_config.json') {
+      return ByteData.sublistView(Uint8List.fromList(bytes));
+    }
+    return null;
+  });
+}
+
+Future<void> clearDefaultConfigAssetMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', null);
+  return Future<void>.value();
+}
+
+Future<List<MethodCall>> mockUrlLauncher({required bool launchResult}) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final calls = <MethodCall>[];
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    _urlLauncherChannel,
+    (MethodCall methodCall) async {
+      calls.add(methodCall);
+      return launchResult;
+    },
+  );
+  return calls;
+}
+
+Future<void> clearUrlLauncherMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_urlLauncherChannel, null);
+  return Future<void>.value();
+}

--- a/test/ui/background_location_disclosure_page_test.dart
+++ b/test/ui/background_location_disclosure_page_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
+
+import 'package:argus/app_controller.dart';
+import 'package:argus/platform/notifier.dart';
+import 'package:argus/platform/permission_coordinator.dart';
+import 'package:argus/state_machine/state_machine.dart';
+import 'package:argus/ui/background_location_disclosure_page.dart';
+
+import '../support/notifier_fakes.dart';
+import '../support/platform_mocks.dart';
+import '../support/test_doubles.dart';
+
+void main() {
+  setUpAll(() async {
+    await mockUrlLauncher(launchResult: true);
+  });
+
+  tearDown(() async {
+    await clearUrlLauncherMock();
+  });
+
+  testWidgets('continue button completes setup and pops true', (tester) async {
+    final controller = _DisclosureTestController();
+    bool? result;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppController>.value(
+        value: controller,
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await showBackgroundLocationDisclosure(context);
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('同意して位置情報の設定へ進む'));
+    await tester.pumpAndSettle();
+
+    expect(controller.completeSetupCount, 1);
+    expect(result, isTrue);
+    expect(find.text('Open'), findsOneWidget);
+  });
+
+  testWidgets('cancel button pops false', (tester) async {
+    final controller = _DisclosureTestController();
+    bool? result;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppController>.value(
+        value: controller,
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await showBackgroundLocationDisclosure(context);
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('今はしない'));
+    await tester.pumpAndSettle();
+
+    expect(controller.completeSetupCount, 0);
+    expect(result, isFalse);
+  });
+
+  testWidgets('privacy policy failure shows snackbar', (tester) async {
+    await clearUrlLauncherMock();
+    await mockUrlLauncher(launchResult: false);
+    final controller = _DisclosureTestController();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppController>.value(
+        value: controller,
+        child: const MaterialApp(home: BackgroundLocationDisclosurePage()),
+      ),
+    );
+
+    await tester.ensureVisible(find.text('Privacy Policy を開く'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Privacy Policy を開く'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('プライバシーポリシーを開けませんでした。'), findsOneWidget);
+  });
+}
+
+class _DisclosureTestController extends AppController {
+  _DisclosureTestController()
+      : super(
+          stateMachine: StateMachine(config: createTestConfig()),
+          locationService: FakeLocationService(),
+          fileManager: FakeFileManager(config: createTestConfig()),
+          logger: FakeEventLogger(),
+          notifier: Notifier(
+            notificationsClient: FakeLocalNotificationsClient(),
+            alarmPlayer: FakeAlarmPlayer(),
+          ),
+          permissionCoordinator: _DisclosurePermissionCoordinator(),
+        ) {
+    debugSeed(
+      config: createTestConfig(),
+      permissionState: MonitoringPermissionState(
+        notificationStatus: PermissionStatus.granted,
+        locationWhenInUseStatus: PermissionStatus.granted,
+        locationAlwaysStatus: PermissionStatus.denied,
+        locationServicesEnabled: true,
+      ),
+    );
+  }
+
+  int completeSetupCount = 0;
+
+  @override
+  Future<void> completeMonitoringPermissionSetup() async {
+    completeSetupCount += 1;
+  }
+}
+
+class _DisclosurePermissionCoordinator extends PermissionCoordinator {}

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -11,6 +11,7 @@ import 'package:argus/io/logger.dart';
 import 'package:argus/platform/location_service.dart';
 import 'package:argus/platform/notifier.dart';
 import 'package:argus/platform/permission_coordinator.dart';
+import 'package:argus/qr/geojson_qr_codec.dart';
 import 'package:argus/state_machine/state_machine.dart';
 import 'package:argus/ui/qr_scanner_page.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -369,6 +370,110 @@ void main() {
       expect(disposeCount, 1);
     });
 
+    testWidgets('returning from settings re-prepares scanner on resume',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      final coordinator = _SequenceCameraPermissionCoordinator(
+        states: const [
+          CameraPermissionState(status: PermissionStatus.granted),
+          CameraPermissionState(status: PermissionStatus.granted),
+        ],
+      );
+      var startCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: coordinator,
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                startCount += 1;
+                if (startCount == 1) {
+                  throw const MobileScannerException(
+                    errorCode: MobileScannerErrorCode.controllerUninitialized,
+                    errorDetails:
+                        MobileScannerErrorDetails(message: 'permission denied'),
+                  );
+                }
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('アプリ設定を開く'), findsOneWidget);
+
+      await tester.tap(find.text('アプリ設定を開く'));
+      await tester.pumpAndSettle();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+
+      expect(startCount, 2);
+      expect(coordinator.ensureCameraPermissionCount, 2);
+      expect(find.text('アプリ設定を開く'), findsNothing);
+    });
+
+    testWidgets('hidden and detached lifecycle states stop scanner',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      var stopCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {},
+              stopScannerOverride: () async {
+                stopCount += 1;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.detached);
+      await tester.pump();
+
+      expect(stopCount, 2);
+    });
+
+    testWidgets('real scanner without stop override handles hidden state',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+
+      expect(find.text('Scan QR Code'), findsOneWidget);
+    });
+
     testWidgets('scanner permission start error offers settings action',
         (WidgetTester tester) async {
       final controller = _buildController();
@@ -429,6 +534,96 @@ void main() {
       expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
     });
 
+    testWidgets('scanner barcode start error shows retry guidance',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw const MobileScannerException(
+                  errorCode: MobileScannerErrorCode.controllerInitializing,
+                  errorDetails: MobileScannerErrorDetails(
+                    message: 'barcode engine unavailable',
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+    });
+
+    testWidgets('scanner download start error shows retry guidance',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw const MobileScannerException(
+                  errorCode: MobileScannerErrorCode.controllerInitializing,
+                  errorDetails: MobileScannerErrorDetails(
+                    message: 'download required',
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+    });
+
+    testWidgets('scanner google play start error shows retry guidance',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw const MobileScannerException(
+                  errorCode: MobileScannerErrorCode.controllerInitializing,
+                  errorDetails: MobileScannerErrorDetails(
+                    message: 'google play services unavailable',
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+    });
+
     testWidgets('scanner generic start error shows generic failure message',
         (WidgetTester tester) async {
       final controller = _buildController();
@@ -452,6 +647,40 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('QR スキャナを開始できませんでした'), findsWidgets);
+    });
+
+    testWidgets('retry in error state restarts scanner when camera already granted',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      var startCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                startCount += 1;
+                if (startCount == 1) {
+                  throw Exception('unexpected');
+                }
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('再試行'), findsOneWidget);
+
+      await tester.tap(find.text('再試行'));
+      await tester.pumpAndSettle();
+
+      expect(startCount, 2);
+      expect(find.text('再試行'), findsNothing);
     });
 
     testWidgets('empty or null barcode payload is ignored',
@@ -530,6 +759,63 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('QR コードの処理中にエラーが発生しました'), findsOneWidget);
+    });
+
+    testWidgets('GeoJsonQrException while loading QR is surfaced',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController()
+        ..reloadError = DecodeFailedException('bad payload');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, scannerController, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      const BarcodeCapture(
+                        barcodes: [Barcode(rawValue: 'gjb1:error')],
+                      ),
+                    ),
+                    child: const Text('Emit Decode Error'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Decode Error'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('QR コードの復元に失敗しました'), findsOneWidget);
+    });
+
+    testWidgets('real scanner branch renders MobileScanner widget',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              startScannerOverride: () async {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MobileScanner), findsOneWidget);
     });
   });
 }
@@ -653,11 +939,13 @@ class _SequenceCameraPermissionCoordinator extends PermissionCoordinator {
   final List<CameraPermissionState> states;
   int _index = 0;
   int openSettingsCount = 0;
+  int ensureCameraPermissionCount = 0;
 
   @override
   Future<CameraPermissionState> ensureCameraPermission({
     bool openSettingsIfNeeded = false,
   }) async {
+    ensureCameraPermissionCount += 1;
     final current = states[_index < states.length ? _index : states.length - 1];
     if (_index < states.length - 1) {
       _index += 1;

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:mobile_scanner/src/enums/mobile_scanner_error_code.dart';
 import 'package:provider/provider.dart';
 
 import 'package:argus/app_controller.dart';
@@ -135,6 +137,400 @@ void main() {
       expect(find.textContaining('カメラ権限'), findsOneWidget);
       expect(find.text('再試行'), findsOneWidget);
     });
+
+    testWidgets('shows settings button when camera requires manual settings',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      final coordinator = _SequenceCameraPermissionCoordinator(
+        states: const [
+          CameraPermissionState(status: PermissionStatus.permanentlyDenied),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: coordinator,
+              scannerOverride: const ColoredBox(color: Colors.black),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('アプリ設定を開く'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('アプリ設定を開く'), findsOneWidget);
+      expect(coordinator.openSettingsCount, 1);
+    });
+
+    testWidgets('retry after permission grant hides error panel',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      final coordinator = _SequenceCameraPermissionCoordinator(
+        states: const [
+          CameraPermissionState(status: PermissionStatus.denied),
+          CameraPermissionState(status: PermissionStatus.granted),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: coordinator,
+              scannerOverride: const ColoredBox(color: Colors.black),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('再試行'), findsOneWidget);
+
+      await tester.tap(find.text('再試行'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('再試行'), findsNothing);
+    });
+
+    testWidgets('invalid QR shows dismissible error banner',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, controller, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      const BarcodeCapture(
+                        barcodes: [Barcode(rawValue: 'not-a-geojson-qr')],
+                      ),
+                    ),
+                    child: const Text('Emit Invalid'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Invalid'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GeoJSON QR コードではありません。'), findsOneWidget);
+      expect(controller.scannedTexts, isEmpty);
+
+      await tester.tap(find.text('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GeoJSON QR コードではありません。'), findsNothing);
+    });
+
+    testWidgets('valid QR displays controller error when load fails',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController()
+        ..loadedResult = false
+        ..reloadErrorMessage = 'GeoJSON の読込に失敗しました。';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, scannerController, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      const BarcodeCapture(
+                        barcodes: [Barcode(rawValue: 'gjb1:test')],
+                      ),
+                    ),
+                    child: const Text('Emit Valid'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Valid'));
+      await tester.pumpAndSettle();
+
+      expect(controller.scannedTexts, ['gjb1:test']);
+      expect(find.text('GeoJSON の読込に失敗しました。'), findsOneWidget);
+    });
+
+    testWidgets('successful QR load pops scanner route', (WidgetTester tester) async {
+      final controller = _RecordingQrController()..loadedResult = true;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => ChangeNotifierProvider<AppController>.value(
+                        value: controller,
+                        child: QrScannerPage(
+                          permissionCoordinator: _FakePermissionCoordinator(),
+                          scannerOverride: const SizedBox.shrink(),
+                          scannerBuilder: (context, scannerController, onDetect) {
+                            return Center(
+                              child: ElevatedButton(
+                                onPressed: () => onDetect(
+                                  const BarcodeCapture(
+                                    barcodes: [Barcode(rawValue: 'gjb1:success')],
+                                  ),
+                                ),
+                                child: const Text('Emit Success'),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Open Scanner'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Scanner'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Success'));
+      await tester.pumpAndSettle();
+
+      expect(controller.scannedTexts, ['gjb1:success']);
+      expect(find.text('Open Scanner'), findsOneWidget);
+      expect(find.text('Scan QR Code'), findsNothing);
+    });
+
+    testWidgets('real scanner lifecycle restarts on resume and stops on pause',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+      var startCount = 0;
+      var stopCount = 0;
+      var disposeCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                startCount += 1;
+              },
+              stopScannerOverride: () async {
+                stopCount += 1;
+              },
+              disposeScannerOverride: () {
+                disposeCount += 1;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(startCount, 2);
+      expect(stopCount, 1);
+      expect(disposeCount, 1);
+    });
+
+    testWidgets('scanner permission start error offers settings action',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw const MobileScannerException(
+                  errorCode: MobileScannerErrorCode.controllerUninitialized,
+                  errorDetails:
+                      MobileScannerErrorDetails(message: 'permission denied'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('アプリ設定から許可してください'), findsOneWidget);
+      expect(find.text('アプリ設定を開く'), findsOneWidget);
+    });
+
+    testWidgets('scanner mlkit start error shows retry guidance',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw const MobileScannerException(
+                  errorCode: MobileScannerErrorCode.controllerInitializing,
+                  errorDetails: MobileScannerErrorDetails(
+                    message: 'mlkit download required',
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+    });
+
+    testWidgets('scanner generic start error shows generic failure message',
+        (WidgetTester tester) async {
+      final controller = _buildController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerBuilder: (context, scannerController, onDetect) =>
+                  const ColoredBox(color: Colors.black),
+              startScannerOverride: () async {
+                throw Exception('unexpected');
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('QR スキャナを開始できませんでした'), findsWidgets);
+    });
+
+    testWidgets('empty or null barcode payload is ignored',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController();
+      var emitNull = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, scannerController, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      BarcodeCapture(
+                        barcodes: emitNull
+                            ? const [Barcode(rawValue: null)]
+                            : const [],
+                      ),
+                    ),
+                    child: const Text('Emit Empty'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Empty'));
+      await tester.pumpAndSettle();
+      emitNull = true;
+      await tester.tap(find.text('Emit Empty'));
+      await tester.pumpAndSettle();
+
+      expect(controller.scannedTexts, isEmpty);
+      expect(find.text('Dismiss'), findsNothing);
+    });
+
+    testWidgets('controller exception while loading QR is surfaced',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController()
+        ..reloadError = Exception('boom');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, scannerController, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      const BarcodeCapture(
+                        barcodes: [Barcode(rawValue: 'gjb1:error')],
+                      ),
+                    ),
+                    child: const Text('Emit Error'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit Error'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('QR コードの処理中にエラーが発生しました'), findsOneWidget);
+    });
   });
 }
 
@@ -235,4 +631,84 @@ class _DeniedCameraPermissionCoordinator extends PermissionCoordinator {
           openLocationSettings: () async => true,
           locationServicesEnabled: () async => true,
         );
+}
+
+AppController _buildController() {
+  final config = _testConfig();
+  return AppController(
+    stateMachine: StateMachine(config: config),
+    locationService: _FakeLocationService(),
+    fileManager: _FakeFileManager(config: config),
+    logger: _FakeEventLogger(),
+    notifier: Notifier(
+      notificationsClient: FakeLocalNotificationsClient(),
+      alarmPlayer: FakeAlarmPlayer(),
+    ),
+  );
+}
+
+class _SequenceCameraPermissionCoordinator extends PermissionCoordinator {
+  _SequenceCameraPermissionCoordinator({required this.states});
+
+  final List<CameraPermissionState> states;
+  int _index = 0;
+  int openSettingsCount = 0;
+
+  @override
+  Future<CameraPermissionState> ensureCameraPermission({
+    bool openSettingsIfNeeded = false,
+  }) async {
+    final current = states[_index < states.length ? _index : states.length - 1];
+    if (_index < states.length - 1) {
+      _index += 1;
+    }
+    return current;
+  }
+
+  @override
+  Future<bool> openSettings() async {
+    openSettingsCount += 1;
+    return true;
+  }
+}
+
+class _RecordingQrController extends AppController {
+  _RecordingQrController()
+      : super(
+          stateMachine: StateMachine(config: _testConfig()),
+          locationService: _FakeLocationService(),
+          fileManager: _FakeFileManager(config: _testConfig()),
+          logger: _FakeEventLogger(),
+          notifier: Notifier(
+            notificationsClient: FakeLocalNotificationsClient(),
+            alarmPlayer: FakeAlarmPlayer(),
+          ),
+        ) {
+    debugSeed(
+      config: _testConfig(),
+      permissionState: const MonitoringPermissionState(
+        notificationStatus: PermissionStatus.granted,
+        locationWhenInUseStatus: PermissionStatus.granted,
+        locationAlwaysStatus: PermissionStatus.granted,
+        locationServicesEnabled: true,
+      ),
+    );
+  }
+
+  final List<String> scannedTexts = <String>[];
+  bool loadedResult = true;
+  String? reloadErrorMessage;
+  Object? reloadError;
+
+  @override
+  Future<bool> reloadGeoJsonFromQr(String qrText) async {
+    scannedTexts.add(qrText);
+    if (reloadError != null) {
+      throw reloadError!;
+    }
+    return loadedResult;
+  }
+
+  @override
+  String? get lastErrorMessage => reloadErrorMessage;
 }

--- a/test/ui/settings_page_test.dart
+++ b/test/ui/settings_page_test.dart
@@ -1,8 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/io/config.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
@@ -13,23 +11,8 @@ import 'package:argus/state_machine/state_machine.dart';
 import 'package:argus/ui/settings_page.dart';
 
 import '../support/notifier_fakes.dart';
+import '../support/platform_mocks.dart';
 import '../support/test_doubles.dart';
-
-Future<void> _mockDefaultConfigAsset() async {
-  TestWidgetsFlutterBinding.ensureInitialized();
-  final bytes = await File('assets/config/default_config.json').readAsBytes();
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(
-    const MethodChannel('flutter/assets'),
-    (MethodCall methodCall) async {
-      if (methodCall.method == 'loadString' &&
-          methodCall.arguments == 'assets/config/default_config.json') {
-        return String.fromCharCodes(bytes);
-      }
-      return null;
-    },
-  );
-}
 
 Future<void> _pumpSettings(
   WidgetTester tester,
@@ -67,9 +50,44 @@ Future<void> _pumpUntilVisible(
   fail('Widget not found after pumping.');
 }
 
+Future<void> _scrollUntilVisible(WidgetTester tester, Finder finder) async {
+  await tester.scrollUntilVisible(
+    finder,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _enterFieldText(
+  WidgetTester tester,
+  Key key,
+  String value,
+) async {
+  final finder = find.byKey(key);
+  await _scrollUntilVisible(tester, finder);
+  await tester.tap(finder);
+  await tester.pump();
+  await tester.enterText(finder, value);
+  await tester.pump();
+}
+
+Future<void> _invokeSaveButton(WidgetTester tester) async {
+  final finder = find.byKey(const Key('saveSettingsButton'));
+  await _scrollUntilVisible(tester, finder);
+  final button = tester.widget<ElevatedButton>(finder);
+  expect(button.onPressed, isNotNull);
+  button.onPressed!.call();
+  await tester.pump();
+}
+
 void main() {
   setUpAll(() async {
-    await _mockDefaultConfigAsset();
+    await mockDefaultConfigAsset();
+  });
+
+  tearDown(() async {
+    await clearUrlLauncherMock();
   });
 
   testWidgets('shows progress indicator when config is null', (tester) async {
@@ -94,14 +112,11 @@ void main() {
     final controller = buildTestController(hasGeoJson: true);
     expect(controller.config, isNotNull);
 
-    await _pumpSettings(tester, controller, settle: false);
-    await _pumpUntilVisible(
-      tester,
-      find.text('反応距離 (Inner buffer)'),
-    );
+    await _pumpSettings(tester, controller);
 
     expect(find.text('反応距離 (Inner buffer)'), findsOneWidget);
     expect(find.text('Privacy Policy'), findsOneWidget);
+    expect(find.textContaining('デフォルト:'), findsWidgets);
   });
 
   testWidgets('toggling developer mode switch calls controller',
@@ -150,4 +165,98 @@ void main() {
       findsWidgets,
     );
   });
+
+  testWidgets('privacy policy failure shows snackbar', (tester) async {
+    await mockUrlLauncher(launchResult: false);
+    final controller = _RecordingSettingsController();
+
+    await _pumpSettings(tester, controller);
+
+    await tester.tap(find.byKey(const Key('privacyPolicyTile')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('プライバシーポリシーを開けませんでした。'), findsOneWidget);
+  });
+
+  testWidgets('export logs opens dialog and can close', (tester) async {
+    final controller = _RecordingSettingsController();
+
+    await _pumpSettings(tester, controller);
+    await _scrollUntilVisible(
+        tester, find.byKey(const Key('exportLogsButton')));
+    await tester.tap(find.byKey(const Key('exportLogsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Export (JSONL)'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Export (JSONL)'), findsNothing);
+  });
+
+  testWidgets('invalid values block save and show validation errors',
+      (tester) async {
+    final controller = _RecordingSettingsController();
+
+    await _pumpSettings(tester, controller);
+    await _enterFieldText(
+      tester,
+      const Key('pollingIntervalField'),
+      '0',
+    );
+    await _enterFieldText(
+      tester,
+      const Key('leaveConfirmSamplesField'),
+      '0',
+    );
+    await _enterFieldText(
+      tester,
+      const Key('leaveConfirmSecondsField'),
+      '0',
+    );
+    await _invokeSaveButton(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1以上の整数を入力してください'), findsWidgets);
+    expect(controller.updateConfigCalls, 0);
+  });
+}
+
+class _RecordingSettingsController extends AppController {
+  _RecordingSettingsController()
+      : super(
+          stateMachine: StateMachine(config: createTestConfig()),
+          locationService: FakeLocationService(),
+          fileManager: FakeFileManager(config: createTestConfig()),
+          logger: FakeEventLogger(),
+          notifier: Notifier(
+            notificationsClient: FakeLocalNotificationsClient(),
+            alarmPlayer: FakeAlarmPlayer(),
+          ),
+        ) {
+    debugSeed(
+      config: createTestConfig(),
+      permissionState: const MonitoringPermissionState(
+        notificationStatus: PermissionStatus.granted,
+        locationWhenInUseStatus: PermissionStatus.granted,
+        locationAlwaysStatus: PermissionStatus.granted,
+        locationServicesEnabled: true,
+      ),
+    );
+  }
+  AppConfig? savedConfig;
+  Object? updateConfigError;
+  int updateConfigCalls = 0;
+
+  @override
+  Future<void> updateConfig(AppConfig newConfig) async {
+    updateConfigCalls += 1;
+    if (updateConfigError != null) {
+      throw updateConfigError!;
+    }
+    savedConfig = newConfig;
+    debugSeed(config: newConfig);
+  }
 }


### PR DESCRIPTION
## Summary
- Remove the dead `consumeBackgroundDisclosurePrompt()` call from `HomePage`
- Stop attempting to auto-open the background location disclosure after frame render
- Keep the remaining explicit disclosure entry points unchanged

## Testing
- `flutter test --coverage`