### PR TITLE
Add Android release workflow, version bump script, and release docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/lcov.info

--- a/.github/workflows/closed_test_release_android.yml
+++ b/.github/workflows/closed_test_release_android.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.actor != 'github-actions[bot]' && github.ref_name != 'main'
@@ -24,6 +28,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Sync branch tip
+        run: |
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/closed_test_release_android.yml
+++ b/.github/workflows/closed_test_release_android.yml
@@ -3,21 +3,27 @@ name: closed_test_release_android
 on:
   push:
     branches-ignore: ["main"]
-  pull_request:
-    branches: ["**"]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && github.ref_name != 'main'
     runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -41,12 +47,7 @@ jobs:
           echo "Closed track: $closed_track"
 
       - name: Restore Android signing config
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.ANDROID_KEY_ALIAS != '' && env.ANDROID_KEY_PASSWORD != '' && env.ANDROID_STORE_PASSWORD != '' }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
 
@@ -56,6 +57,21 @@ jobs:
           keyAlias=$ANDROID_KEY_ALIAS
           keyPassword=$ANDROID_KEY_PASSWORD
           KEYS
+
+      - name: Bump patch version
+        run: scripts/bump_version.sh pubspec.yaml patch
+
+      - name: Commit bumped version
+        run: |
+          if git diff --quiet -- pubspec.yaml; then
+            echo "No version changes to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add pubspec.yaml
+            git commit -m "chore(release): bump patch version [skip release]"
+            git push origin HEAD:"${GITHUB_REF_NAME}"
+          fi
 
       - name: Get dependencies
         run: flutter pub get
@@ -74,10 +90,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to Google Play closed testing
-        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON != '' }}
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          serviceAccountJsonPlainText: ${{ env.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.argus.orienteering
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: ${{ steps.closed_track.outputs.name }}

--- a/.github/workflows/closed_test_release_android.yml
+++ b/.github/workflows/closed_test_release_android.yml
@@ -1,0 +1,85 @@
+name: closed_test_release_android
+
+on:
+  push:
+    branches-ignore: ["main"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Resolve closed track name
+        id: closed_track
+        run: |
+          closed_track="${{ vars.PLAY_CLOSED_TRACK }}"
+          if [[ -z "$closed_track" ]]; then
+            closed_track="beta"
+          fi
+          echo "name=$closed_track" >> "$GITHUB_OUTPUT"
+          echo "Closed track: $closed_track"
+
+      - name: Restore Android signing config
+        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
+
+          cat > android/key.properties <<KEYS
+          storeFile=$RUNNER_TEMP/release-keystore.jks
+          storePassword=$ANDROID_STORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          KEYS
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build release appbundle
+        run: flutter build appbundle --release
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-closed-artifacts
+          path: |
+            build/app/outputs/bundle/release/app-release.aab
+            build/app/outputs/mapping/release/mapping.txt
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload to Google Play closed testing
+        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.argus.orienteering
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: ${{ steps.closed_track.outputs.name }}
+          status: completed
+          inAppUpdatePriority: 2

--- a/.github/workflows/closed_test_release_android.yml
+++ b/.github/workflows/closed_test_release_android.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -89,7 +89,7 @@ jobs:
         run: flutter build appbundle --release
 
       - name: Upload Android artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-closed-artifacts
           path: |

--- a/.github/workflows/closed_test_release_android.yml
+++ b/.github/workflows/closed_test_release_android.yml
@@ -67,8 +67,8 @@ jobs:
           keyPassword=$ANDROID_KEY_PASSWORD
           KEYS
 
-      - name: Bump patch version
-        run: scripts/bump_version.sh pubspec.yaml patch
+      - name: Bump Android versionCode
+        run: scripts/bump_version.sh pubspec.yaml code
 
       - name: Commit bumped version
         run: |
@@ -78,7 +78,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add pubspec.yaml
-            git commit -m "chore(release): bump patch version [skip release]"
+            git commit -m "chore(release): bump versionCode [skip release]"
             git push origin HEAD:"${GITHUB_REF_NAME}"
           fi
 

--- a/.github/workflows/production_release_android.yml
+++ b/.github/workflows/production_release_android.yml
@@ -11,6 +11,12 @@ jobs:
   release:
     if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
 
     steps:
       - name: Checkout repository
@@ -30,12 +36,7 @@ jobs:
           channel: stable
 
       - name: Restore Android signing config
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' && env.ANDROID_KEY_ALIAS != '' && env.ANDROID_KEY_PASSWORD != '' && env.ANDROID_STORE_PASSWORD != '' }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
 
@@ -46,8 +47,20 @@ jobs:
           keyPassword=$ANDROID_KEY_PASSWORD
           KEYS
 
-      - name: Bump Android versionCode
-        run: scripts/bump_version.sh pubspec.yaml
+      - name: Resolve version bump
+        id: version_bump
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          bump="minor"
+          if [[ "$COMMIT_MESSAGE" =~ \[version:(major|minor|patch)\] ]]; then
+            bump="${BASH_REMATCH[1]}"
+          fi
+          echo "part=$bump" >> "$GITHUB_OUTPUT"
+          echo "Version bump: $bump"
+
+      - name: Bump app version
+        run: scripts/bump_version.sh pubspec.yaml "${{ steps.version_bump.outputs.part }}"
 
       - name: Commit bumped version
         run: |
@@ -57,8 +70,8 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add pubspec.yaml
-            git commit -m "chore(release): bump versionCode [skip release]"
-            git push
+            git commit -m "chore(release): bump ${{ steps.version_bump.outputs.part }} version [skip release]"
+            git push origin HEAD:"${GITHUB_REF_NAME}"
           fi
 
       - name: Get dependencies
@@ -78,10 +91,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to Google Play production
-        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ env.PLAY_SERVICE_ACCOUNT_JSON != '' }}
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          serviceAccountJsonPlainText: ${{ env.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.argus.orienteering
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: production

--- a/.github/workflows/production_release_android.yml
+++ b/.github/workflows/production_release_android.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
@@ -23,6 +27,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Sync branch tip
+        run: |
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/production_release_android.yml
+++ b/.github/workflows/production_release_android.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -90,7 +90,7 @@ jobs:
         run: flutter build appbundle --release
 
       - name: Upload Android artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-production-artifacts
           path: |

--- a/.github/workflows/production_release_android.yml
+++ b/.github/workflows/production_release_android.yml
@@ -1,18 +1,15 @@
-name: Android Release
+name: production_release_android
 
 on:
   push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
-  workflow_dispatch:
+    branches: ["main"]
 
 permissions:
   contents: write
 
 jobs:
   release:
-    if: github.actor != 'github-actions[bot]' && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip release]'))
+    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
 
     steps:
@@ -32,22 +29,6 @@ jobs:
         with:
           channel: stable
 
-      - name: Decide release track
-        id: decide_track
-        run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "track=production" >> "$GITHUB_OUTPUT"
-            echo "target=main push -> production"
-          else
-            # closed testing track。必要なら repository variable PLAY_CLOSED_TRACK で上書き可能
-            closed_track="${{ vars.PLAY_CLOSED_TRACK }}"
-            if [[ -z "$closed_track" ]]; then
-              closed_track="beta"
-            fi
-            echo "track=$closed_track" >> "$GITHUB_OUTPUT"
-            echo "target=non-main push / pull_request / manual -> $closed_track"
-          fi
-
       - name: Restore Android signing config
         if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
         env:
@@ -66,11 +47,9 @@ jobs:
           KEYS
 
       - name: Bump Android versionCode
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: scripts/bump_version.sh pubspec.yaml
 
       - name: Commit bumped version
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           if git diff --quiet -- pubspec.yaml; then
             echo "No version changes to commit"
@@ -91,20 +70,20 @@ jobs:
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: android-release-artifacts
+          name: android-release-production-artifacts
           path: |
             build/app/outputs/bundle/release/app-release.aab
             build/app/outputs/mapping/release/mapping.txt
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Upload to Google Play
+      - name: Upload to Google Play production
         if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.argus.orienteering
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          track: ${{ steps.decide_track.outputs.track }}
+          track: production
           status: completed
           inAppUpdatePriority: 2

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -2,14 +2,17 @@ name: Android Release
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   release:
-    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
+    if: github.actor != 'github-actions[bot]' && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip release]'))
     runs-on: ubuntu-latest
 
     steps:
@@ -29,18 +32,30 @@ jobs:
         with:
           channel: stable
 
+      - name: Decide release track
+        id: decide_track
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "track=production" >> "$GITHUB_OUTPUT"
+            echo "target=main push -> production"
+          else
+            # closed testing track。必要なら repository variable PLAY_CLOSED_TRACK で上書き可能
+            closed_track="${{ vars.PLAY_CLOSED_TRACK }}"
+            if [[ -z "$closed_track" ]]; then
+              closed_track="beta"
+            fi
+            echo "track=$closed_track" >> "$GITHUB_OUTPUT"
+            echo "target=non-main push / pull_request / manual -> $closed_track"
+          fi
+
       - name: Restore Android signing config
+        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.ANDROID_STORE_PASSWORD != '' }}
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
         run: |
-          test -n "$ANDROID_KEYSTORE_BASE64"
-          test -n "$ANDROID_KEY_ALIAS"
-          test -n "$ANDROID_KEY_PASSWORD"
-          test -n "$ANDROID_STORE_PASSWORD"
-
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
 
           cat > android/key.properties <<KEYS
@@ -51,9 +66,11 @@ jobs:
           KEYS
 
       - name: Bump Android versionCode
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: scripts/bump_version.sh pubspec.yaml
 
       - name: Commit bumped version
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           if git diff --quiet -- pubspec.yaml; then
             echo "No version changes to commit"
@@ -81,12 +98,13 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Upload to Google Play internal track
+      - name: Upload to Google Play
+        if: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.argus.orienteering
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
-          track: internal
+          track: ${{ steps.decide_track.outputs.track }}
           status: completed
           inAppUpdatePriority: 2

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,92 @@
+name: Android Release
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip release]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Restore Android signing config
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64"
+          test -n "$ANDROID_KEY_ALIAS"
+          test -n "$ANDROID_KEY_PASSWORD"
+          test -n "$ANDROID_STORE_PASSWORD"
+
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
+
+          cat > android/key.properties <<KEYS
+          storeFile=$RUNNER_TEMP/release-keystore.jks
+          storePassword=$ANDROID_STORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          KEYS
+
+      - name: Bump Android versionCode
+        run: scripts/bump_version.sh pubspec.yaml
+
+      - name: Commit bumped version
+        run: |
+          if git diff --quiet -- pubspec.yaml; then
+            echo "No version changes to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add pubspec.yaml
+            git commit -m "chore(release): bump versionCode [skip release]"
+            git push
+          fi
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build release appbundle
+        run: flutter build appbundle --release
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-artifacts
+          path: |
+            build/app/outputs/bundle/release/app-release.aab
+            build/app/outputs/mapping/release/mapping.txt
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload to Google Play internal track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.argus.orienteering
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+          inAppUpdatePriority: 2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![codecov](https://codecov.io/gh/nanigasi-san/Argus/branch/main/graph/badge.svg)](https://codecov.io/gh/YOUR_USERNAME/Argus)
 [![CI](https://github.com/nanigasi-san/Argus/workflows/CI/badge.svg)](https://github.com/YOUR_USERNAME/Argus/actions)
 
+## リリース運用
+
+Android AAB のproduction / closed test配信とバージョン更新オプションは [docs/release.md](docs/release.md) を参照してください。
+
 ## テストカバレッジ
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,26 +4,31 @@
 
 ## ワークフロー
 
-- ファイル: `.github/workflows/release-android.yml`
+### 1) production_release_android
+
+- ファイル: `.github/workflows/production_release_android.yml`
+- トリガー: `main` への `push`
+- 配信先: `production`
+- 実行内容:
+  1. 署名鍵情報を復元
+  2. `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
+  3. version bump を bot で commit/push（`[skip release]` 付き）
+  4. AAB をビルド
+  5. Play Console の production にアップロード
+
+### 2) closed_test_release_android
+
+- ファイル: `.github/workflows/closed_test_release_android.yml`
 - トリガー:
-  - `push`（全ブランチ）
-  - `pull_request`（全ブランチ）
+  - `main` 以外への `push`
+  - `pull_request`
   - `workflow_dispatch`（手動実行）
-
-## 配信トラックのルール
-
-- `main` への `push`: **production** に配信
-- 上記以外（main以外へのpush / pull_request / workflow_dispatch）: **closed testing** に配信
-  - デフォルトは `beta` トラック
+- 配信先: closed testing（デフォルト `beta`）
   - `Repository Variables` の `PLAY_CLOSED_TRACK` で上書き可能
-
-## 実行内容
-
-1. （Secretsがある場合）署名鍵情報を復元
-2. `main` push のときだけ `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
-3. `main` push のときだけ version bump を bot で commit/push（`[skip release]` 付き）
-4. AAB をビルド
-5. Play Console へ配信（track は上記ルールで自動選択）
+- 実行内容:
+  1. 署名鍵情報を復元
+  2. AAB をビルド
+  3. Play Console の closed testing track へアップロード
 
 ## 必須 Secrets
 
@@ -55,14 +60,14 @@ base64 -w 0 release-keystore.jks
 ## 運用メモ
 
 - `versionName`（`x.y.z`）は手動管理です。必要時のみ `pubspec.yaml` で更新します。
-- `versionCode`（`+n` の n）は `main` push 時のみ自動更新されます。
+- `versionCode`（`+n` の n）は `production_release_android`（main push）時のみ自動更新されます。
 - bot commit には `[skip release]` を付与して再実行ループを抑止します。
+- `pull_request`（特にfork由来）で Secrets が使えない場合は、Play への upload step はスキップされます。
 
 ## トラブルシュート
 
 - 署名エラー: keystore の base64 文字列破損、alias/password 不一致を確認
 - 配信エラー: サービスアカウントの権限不足または packageName 不一致を確認
-- pull_request（特にfork由来）で Secrets が使えない場合は、Play への upload step はスキップされます
 
 ## PR運用ルール
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,52 @@
+# Android リリース自動化運用
+
+このプロジェクトでは、`main` への push を契機に GitHub Actions で Android AAB のビルドと Play Console への配信を行います。
+
+## ワークフロー
+
+- ファイル: `.github/workflows/release-android.yml`
+- トリガー: `main` ブランチへの push
+- 実行内容:
+  1. 署名鍵情報を Secrets から復元
+  2. `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
+  3. 変更を bot で main に commit/push（`[skip release]` 付き）
+  4. AAB をビルド
+  5. Play Console の `internal` track にアップロード
+
+## 必須 Secrets
+
+以下の Secrets を GitHub Repository Settings > Secrets and variables > Actions に登録してください。
+
+- `ANDROID_KEYSTORE_BASE64`
+  - `release-keystore.jks` を base64 化した文字列
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+- `ANDROID_STORE_PASSWORD`
+- `PLAY_SERVICE_ACCOUNT_JSON`
+  - Play Developer API 権限を持つサービスアカウントの JSON
+
+### base64 作成例
+
+```bash
+base64 -w 0 release-keystore.jks
+```
+
+> macOS の場合は `base64 release-keystore.jks | tr -d '\n'` を利用してください。
+
+## 初期セットアップ確認
+
+1. Play Console 側で対象アプリにサービスアカウントを招待済みであること
+2. サービスアカウントに「リリース管理」相当の権限があること
+3. `android/key.properties` はリポジトリに含めず、CIで毎回生成されること
+
+## 運用メモ
+
+- `versionName`（`x.y.z`）は手動管理です。必要時のみ `pubspec.yaml` で更新します。
+- `versionCode`（`+n` の n）は workflow により自動更新されます。
+- internal track で検証後、production への昇格は Play Console 側で実施してください。
+
+## トラブルシュート
+
+- 署名エラー: keystore の base64 文字列破損、alias/password 不一致を確認
+- 配信エラー: サービスアカウントの権限不足または packageName 不一致を確認
+- ループ実行: bot commit には `[skip release]` を付与して再実行を抑止

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,17 +1,29 @@
 # Android リリース自動化運用
 
-このプロジェクトでは、`main` への push を契機に GitHub Actions で Android AAB のビルドと Play Console への配信を行います。
+このプロジェクトでは、GitHub Actions で Android AAB のビルドと Play Console への配信を行います。
 
 ## ワークフロー
 
 - ファイル: `.github/workflows/release-android.yml`
-- トリガー: `main` ブランチへの push
-- 実行内容:
-  1. 署名鍵情報を Secrets から復元
-  2. `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
-  3. 変更を bot で main に commit/push（`[skip release]` 付き）
-  4. AAB をビルド
-  5. Play Console の `internal` track にアップロード
+- トリガー:
+  - `push`（全ブランチ）
+  - `pull_request`（全ブランチ）
+  - `workflow_dispatch`（手動実行）
+
+## 配信トラックのルール
+
+- `main` への `push`: **production** に配信
+- 上記以外（main以外へのpush / pull_request / workflow_dispatch）: **closed testing** に配信
+  - デフォルトは `beta` トラック
+  - `Repository Variables` の `PLAY_CLOSED_TRACK` で上書き可能
+
+## 実行内容
+
+1. （Secretsがある場合）署名鍵情報を復元
+2. `main` push のときだけ `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
+3. `main` push のときだけ version bump を bot で commit/push（`[skip release]` 付き）
+4. AAB をビルド
+5. Play Console へ配信（track は上記ルールで自動選択）
 
 ## 必須 Secrets
 
@@ -38,21 +50,21 @@ base64 -w 0 release-keystore.jks
 1. Play Console 側で対象アプリにサービスアカウントを招待済みであること
 2. サービスアカウントに「リリース管理」相当の権限があること
 3. `android/key.properties` はリポジトリに含めず、CIで毎回生成されること
+4. closed track を `beta` 以外にしたい場合は `PLAY_CLOSED_TRACK` を設定すること
 
 ## 運用メモ
 
 - `versionName`（`x.y.z`）は手動管理です。必要時のみ `pubspec.yaml` で更新します。
-- `versionCode`（`+n` の n）は workflow により自動更新されます。
-- internal track で検証後、production への昇格は Play Console 側で実施してください。
+- `versionCode`（`+n` の n）は `main` push 時のみ自動更新されます。
+- bot commit には `[skip release]` を付与して再実行ループを抑止します。
 
 ## トラブルシュート
 
 - 署名エラー: keystore の base64 文字列破損、alias/password 不一致を確認
 - 配信エラー: サービスアカウントの権限不足または packageName 不一致を確認
-- ループ実行: bot commit には `[skip release]` を付与して再実行を抑止
+- pull_request（特にfork由来）で Secrets が使えない場合は、Play への upload step はスキップされます
 
 ## PR運用ルール
 
 - リリース自動化に関する PR タイトル・本文は日本語で記載します。
 - PR 本文には `created by Codex` を含めます。
-

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,75 +1,112 @@
-# Android リリース自動化運用
+# Android リリース運用
 
-このプロジェクトでは、GitHub Actions で Android AAB のビルドと Play Console への配信を行います。
+このプロジェクトでは GitHub Actions で Android AAB をビルドし、Google Play Console へ配信します。
 
-## ワークフロー
+## 配信フロー
 
-### 1) production_release_android
+### main: production 配信
 
-- ファイル: `.github/workflows/production_release_android.yml`
-- トリガー: `main` への `push`
-- 配信先: `production`
-- 実行内容:
-  1. 署名鍵情報を復元
-  2. `pubspec.yaml` の `versionCode`（`x.y.z+n` の `n`）を +1
-  3. version bump を bot で commit/push（`[skip release]` 付き）
-  4. AAB をビルド
-  5. Play Console の production にアップロード
+- Workflow: `.github/workflows/production_release_android.yml`
+- Trigger: `main` への `push`
+- Track: `production`
+- Version: `pubspec.yaml` の `version: x.y.z+n` を更新してからAABを作成
+  - デフォルトは `minor`
+  - bot commit には `[skip release]` が付き、再実行ループを防ぎます
 
-### 2) closed_test_release_android
+mainでのバージョン更新オプションは、pushするcommit messageに次のどれかを含めて指定します。
 
-- ファイル: `.github/workflows/closed_test_release_android.yml`
-- トリガー:
-  - `main` 以外への `push`
-  - `pull_request`
-  - `workflow_dispatch`（手動実行）
-- 配信先: closed testing（デフォルト `beta`）
-  - `Repository Variables` の `PLAY_CLOSED_TRACK` で上書き可能
-- 実行内容:
-  1. 署名鍵情報を復元
-  2. AAB をビルド
-  3. Play Console の closed testing track へアップロード
+```text
+[version:major]  # 0.2.3+6 -> 1.0.0+7
+[version:minor]  # 0.2.3+6 -> 0.3.0+7
+[version:patch]  # 0.2.3+6 -> 0.2.4+7
+```
 
-## 必須 Secrets
+指定しない場合は `[version:minor]` と同じ扱いです。
 
-以下の Secrets を GitHub Repository Settings > Secrets and variables > Actions に登録してください。
+### main以外: closed test 配信
+
+- Workflow: `.github/workflows/closed_test_release_android.yml`
+- Trigger: `main` 以外への `push`、または手動実行
+- Track: `PLAY_CLOSED_TRACK` repository variable の値
+  - 未設定の場合は `beta`
+- Version: `versionCode` だけ更新
+  - 例: `0.2.3+6 -> 0.2.3+7`
+  - Google Playは同じ `versionCode` の再アップロードを拒否するため、closed testでも `+n` は毎回上げます
+
+## バージョン更新コマンド
+
+ローカルで確認・手動更新したい場合は `scripts/bump_version.sh` を使います。
+
+```bash
+scripts/bump_version.sh pubspec.yaml major
+scripts/bump_version.sh pubspec.yaml minor
+scripts/bump_version.sh pubspec.yaml patch
+scripts/bump_version.sh pubspec.yaml code
+```
+
+各オプションの意味:
+
+| option | 更新例 | 用途 |
+| --- | --- | --- |
+| `major` | `0.2.3+6 -> 1.0.0+7` | 大きな互換性変更、正式版の区切り |
+| `minor` | `0.2.3+6 -> 0.3.0+7` | 通常のproduction更新。mainのデフォルト |
+| `patch` | `0.2.3+6 -> 0.2.4+7` | 小さな修正をproductionへ出す場合 |
+| `code` | `0.2.3+6 -> 0.2.3+7` | closed test用。表示バージョンは変えずGoogle Play用のビルド番号だけ上げる |
+
+## GitHub Secrets / Variables
+
+Repository Settings > Secrets and variables > Actions に登録します。
+
+Secrets:
 
 - `ANDROID_KEYSTORE_BASE64`
-  - `release-keystore.jks` を base64 化した文字列
+  - upload keystore `.jks` をbase64化した文字列
 - `ANDROID_KEY_ALIAS`
 - `ANDROID_KEY_PASSWORD`
 - `ANDROID_STORE_PASSWORD`
 - `PLAY_SERVICE_ACCOUNT_JSON`
-  - Play Developer API 権限を持つサービスアカウントの JSON
+  - Google Play Developer APIを使えるservice account JSON
 
-### base64 作成例
+Variables:
 
-```bash
-base64 -w 0 release-keystore.jks
+- `PLAY_CLOSED_TRACK`
+  - closed testing track名
+  - 未設定時は `beta`
+
+PowerShellでkeystore系Secretを登録する例:
+
+```powershell
+$repo = "nanigasi-san/Argus"
+$props = @{}
+Get-Content "android/key.properties" | ForEach-Object {
+  if ($_ -match '^([^=]+)=(.*)$') { $props[$matches[1]] = $matches[2] }
+}
+
+$base64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes("android/app/upload-keystore.jks"))
+
+gh secret set ANDROID_KEYSTORE_BASE64 --repo $repo --body $base64
+gh secret set ANDROID_KEY_ALIAS --repo $repo --body $props["keyAlias"]
+gh secret set ANDROID_STORE_PASSWORD --repo $repo --body $props["storePassword"]
+gh secret set ANDROID_KEY_PASSWORD --repo $repo --body $props["keyPassword"]
 ```
-
-> macOS の場合は `base64 release-keystore.jks | tr -d '\n'` を利用してください。
-
-## 初期セットアップ確認
-
-1. Play Console 側で対象アプリにサービスアカウントを招待済みであること
-2. サービスアカウントに「リリース管理」相当の権限があること
-3. `android/key.properties` はリポジトリに含めず、CIで毎回生成されること
-4. closed track を `beta` 以外にしたい場合は `PLAY_CLOSED_TRACK` を設定すること
 
 ## 運用メモ
 
-- `versionName`（`x.y.z`）は手動管理です。必要時のみ `pubspec.yaml` で更新します。
-- `versionCode`（`+n` の n）は `production_release_android`（main push）時のみ自動更新されます。
-- bot commit には `[skip release]` を付与して再実行ループを抑止します。
-- `pull_request`（特にfork由来）で Secrets が使えない場合は、Play への upload step はスキップされます。
+- `android/key.properties` と `.jks` はリポジトリに含めません。
+- `PLAY_SERVICE_ACCOUNT_JSON` が未設定の場合、AAB artifactは作られますがGoogle Play upload stepはスキップされます。
+- 同じbranchで古いCD実行が残っている場合は `concurrency` により新しい実行が優先されます。
+- GitHub公式ActionsはNode 24対応版を使います。
+  - `actions/checkout@v6`
+  - `actions/setup-java@v5`
+  - `actions/upload-artifact@v7`
 
 ## トラブルシュート
 
-- 署名エラー: keystore の base64 文字列破損、alias/password 不一致を確認
-- 配信エラー: サービスアカウントの権限不足または packageName 不一致を確認
-
-## PR運用ルール
-
-- リリース自動化に関する PR タイトル・本文は日本語で記載します。
-- PR 本文には `created by Codex` を含めます。
+- non-fast-forwardでpushに失敗する
+  - workflowはcheckout後にremote branch先端へ同期します。古いworkflow定義で走った実行はキャンセルして再実行してください。
+- 署名エラー
+  - `ANDROID_KEYSTORE_BASE64`、alias、store password、key password の不一致を確認してください。
+- Play uploadがスキップされる
+  - `PLAY_SERVICE_ACCOUNT_JSON` がActions Secretに登録されているか確認してください。
+- Play uploadが権限エラーになる
+  - Play Consoleでservice accountに対象アプリのproduction/closed testing release権限があるか確認してください。

--- a/docs/release.md
+++ b/docs/release.md
@@ -50,3 +50,9 @@ base64 -w 0 release-keystore.jks
 - 署名エラー: keystore の base64 文字列破損、alias/password 不一致を確認
 - 配信エラー: サービスアカウントの権限不足または packageName 不一致を確認
 - ループ実行: bot commit には `[skip release]` を付与して再実行を抑止
+
+## PR運用ルール
+
+- リリース自動化に関する PR タイトル・本文は日本語で記載します。
+- PR 本文には `created by Codex` を含めます。
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: 'none'
-version: 0.2.5+8
+version: 0.2.5+9
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: 'none'
-version: 0.2.5+9
+version: 0.2.5+10
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: 'none'
-version: 0.2.2+5
+version: 0.2.3+6
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: 'none'
-version: 0.2.3+6
+version: 0.2.4+7
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: 'none'
-version: 0.2.4+7
+version: 0.2.5+8
 environment:
   sdk: '>=3.2.0 <4.0.0'
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,7 +1,49 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PUBSPEC_FILE="${1:-pubspec.yaml}"
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/bump_version.sh [pubspec.yaml] [major|minor|patch]
+  scripts/bump_version.sh [major|minor|patch]
+
+Defaults to pubspec.yaml and patch.
+
+Examples:
+  scripts/bump_version.sh patch
+  scripts/bump_version.sh pubspec.yaml minor
+  scripts/bump_version.sh pubspec.yaml major
+USAGE
+}
+
+PUBSPEC_FILE="pubspec.yaml"
+BUMP_PART="patch"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    major|minor|patch)
+      BUMP_PART="$1"
+      ;;
+    *)
+      PUBSPEC_FILE="$1"
+      BUMP_PART="${2:-patch}"
+      ;;
+  esac
+fi
+
+case "$BUMP_PART" in
+  major|minor|patch) ;;
+  *)
+    echo "unsupported bump part: $BUMP_PART" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
 
 if [[ ! -f "$PUBSPEC_FILE" ]]; then
   echo "pubspec file not found: $PUBSPEC_FILE" >&2
@@ -18,13 +60,37 @@ current_version="${current_line#version: }"
 base_version="${current_version%%+*}"
 current_code="${current_version##*+}"
 
+if ! [[ "$base_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "invalid versionName: $base_version" >&2
+  exit 1
+fi
+
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+
 if ! [[ "$current_code" =~ ^[0-9]+$ ]]; then
   echo "invalid versionCode: $current_code" >&2
   exit 1
 fi
 
+case "$BUMP_PART" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+esac
+
 next_code=$((current_code + 1))
-next_version="${base_version}+${next_code}"
+next_version="${major}.${minor}.${patch}+${next_code}"
 
 awk -v old="$current_line" -v new="version: ${next_version}" '
   BEGIN { replaced = 0 }
@@ -44,4 +110,4 @@ awk -v old="$current_line" -v new="version: ${next_version}" '
 ' "$PUBSPEC_FILE" > "${PUBSPEC_FILE}.tmp"
 mv "${PUBSPEC_FILE}.tmp" "$PUBSPEC_FILE"
 
-echo "Bumped version: ${current_version} -> ${next_version}"
+echo "Bumped version (${BUMP_PART}): ${current_version} -> ${next_version}"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PUBSPEC_FILE="${1:-pubspec.yaml}"
+
+if [[ ! -f "$PUBSPEC_FILE" ]]; then
+  echo "pubspec file not found: $PUBSPEC_FILE" >&2
+  exit 1
+fi
+
+current_line="$(awk '/^version:[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$/ {print; exit}' "$PUBSPEC_FILE")"
+if [[ -z "$current_line" ]]; then
+  echo "version line not found or unsupported format in $PUBSPEC_FILE" >&2
+  exit 1
+fi
+
+current_version="${current_line#version: }"
+base_version="${current_version%%+*}"
+current_code="${current_version##*+}"
+
+if ! [[ "$current_code" =~ ^[0-9]+$ ]]; then
+  echo "invalid versionCode: $current_code" >&2
+  exit 1
+fi
+
+next_code=$((current_code + 1))
+next_version="${base_version}+${next_code}"
+
+awk -v old="$current_line" -v new="version: ${next_version}" '
+  BEGIN { replaced = 0 }
+  {
+    if (!replaced && $0 == old) {
+      print new
+      replaced = 1
+    } else {
+      print
+    }
+  }
+  END {
+    if (!replaced) {
+      exit 1
+    }
+  }
+' "$PUBSPEC_FILE" > "${PUBSPEC_FILE}.tmp"
+mv "${PUBSPEC_FILE}.tmp" "$PUBSPEC_FILE"
+
+echo "Bumped version: ${current_version} -> ${next_version}"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  scripts/bump_version.sh [pubspec.yaml] [major|minor|patch]
-  scripts/bump_version.sh [major|minor|patch]
+  scripts/bump_version.sh [pubspec.yaml] [major|minor|patch|code]
+  scripts/bump_version.sh [major|minor|patch|code]
 
 Defaults to pubspec.yaml and patch.
 
@@ -13,6 +13,7 @@ Examples:
   scripts/bump_version.sh patch
   scripts/bump_version.sh pubspec.yaml minor
   scripts/bump_version.sh pubspec.yaml major
+  scripts/bump_version.sh pubspec.yaml code
 USAGE
 }
 
@@ -26,7 +27,7 @@ fi
 
 if [[ $# -gt 0 ]]; then
   case "$1" in
-    major|minor|patch)
+    major|minor|patch|code)
       BUMP_PART="$1"
       ;;
     *)
@@ -37,7 +38,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 case "$BUMP_PART" in
-  major|minor|patch) ;;
+  major|minor|patch|code) ;;
   *)
     echo "unsupported bump part: $BUMP_PART" >&2
     usage >&2
@@ -86,6 +87,8 @@ case "$BUMP_PART" in
     ;;
   patch)
     patch=$((patch + 1))
+    ;;
+  code)
     ;;
 esac
 


### PR DESCRIPTION
## 背景・目的（Motivation）

* `main` ブランチへ push した際に、Android の AAB ファイルを自動ビルドし、Google Play Console へ公開できるようにして、リリース作業を効率化する。
* `pubspec.yaml` 内の `versionCode` を自動で増加させ、重複エラーを防ぎつつ、CI 側でバージョン管理できるようにする。
* 必要な Secrets や初期設定手順を明文化し、手作業ミスを減らす。

---

## 変更内容（Description）

### 1. GitHub Actions ワークフロー追加

`.github/workflows/release-android.yml` を追加し、Android リリース用パイプラインを構築。

主な処理内容：

* Android keystore を Base64 化した GitHub Secrets から復元
* Java / Flutter 環境をセットアップ
* `versionCode` を自動インクリメント
* 更新内容を `[skip release]` 付きコミットで push（無限ループ防止）
* AAB ファイルをビルド
* 成果物（artifact）をアップロード
* `r0adkll/upload-google-play` を使って Google Play の internal track に公開

---

### 2. バージョン更新スクリプト追加

`scripts/bump_version.sh` を追加。

機能：

* `pubspec.yaml` の以下形式を解析

```yaml
version: x.y.z+n
```

* `+n` 部分（versionCode）を `n+1` に更新
* 書き戻し実施
* 想定外フォーマットの場合はエラー終了

---

### 3. ドキュメント追加

`docs/release.md` を追加（日本語）。

記載内容：

* ワークフローの起動条件
* 必要な GitHub Secrets 一覧
* keystore を Base64 化する方法
* 運用時の注意点

---

## テスト（Testing）

* 自動テストは追加されていません。
* この変更に伴うテスト実行も行われていません。
