### PR TITLE
アプリ内QR生成とgjz1読み込み互換を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
+      - name: Analyze code
+        run: flutter analyze
+
       - name: Run tests with coverage
         run: flutter test --coverage
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,11 +7,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
 
     <application
         android:label="ARGUS"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:requestLegacyExternalStorage="true">
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="barcode" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,10 @@
   <string>バックグラウンド実行中も安全エリアを監視するため、常時の位置情報アクセスが必要です。</string>
   <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
   <string>安全エリアからの離脱を検知するため、常に位置情報を取得します。</string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>生成したQRコード画像を写真ライブラリに保存するために使用します。</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>生成したQRコード画像を写真ライブラリに保存するために使用します。</string>
   <key>UILaunchStoryboardName</key>
   <string>LaunchScreen</string>
   <key>UIMainStoryboardFile</key>

--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'geo/area_index.dart';
@@ -18,6 +19,8 @@ import 'qr/geojson_qr_codec.dart';
 import 'state_machine/state.dart';
 import 'state_machine/state_machine.dart';
 
+typedef QrImageAnalyzer = Future<String?> Function(String imagePath);
+
 /// アプリケーション全体の状態と動作を管理するコントローラ。
 ///
 /// 位置情報の監視、GeoJSONの読み込み、設定管理、ログ記録などを統合的に処理します。
@@ -30,9 +33,13 @@ class AppController extends ChangeNotifier {
     required this.logger,
     required this.notifier,
     PermissionCoordinator? permissionCoordinator,
-  }) : permissionCoordinator = permissionCoordinator ?? PermissionCoordinator();
+    QrImageAnalyzer? qrImageAnalyzer,
+  })  : permissionCoordinator =
+            permissionCoordinator ?? PermissionCoordinator(),
+        _qrImageAnalyzer = qrImageAnalyzer ?? _defaultQrImageAnalyzer;
 
   final PermissionCoordinator permissionCoordinator;
+  final QrImageAnalyzer _qrImageAnalyzer;
 
   final StateMachine stateMachine;
   final LocationService locationService;
@@ -364,6 +371,40 @@ class AppController extends ChangeNotifier {
     }
   }
 
+  /// QRコード画像ファイルからGeoJSONを読み込みます。
+  Future<bool> reloadGeoJsonFromQrImagePicker() async {
+    await stopMonitoring();
+
+    try {
+      final file = await fileManager.pickQrImageFile();
+      if (file == null) {
+        return false;
+      }
+
+      final qrText = await _qrImageAnalyzer(file.path);
+      if (qrText == null || qrText.trim().isEmpty) {
+        _lastErrorMessage = 'QRコード画像からQRコードを読み取れませんでした。';
+        _logError('APP', _lastErrorMessage!);
+        notifyListeners();
+        return false;
+      }
+
+      return reloadGeoJsonFromQr(qrText);
+    } catch (e) {
+      final errorMessage = e.toString().toLowerCase();
+      if (errorMessage.contains('cancel') ||
+          errorMessage.contains('user') ||
+          errorMessage.contains('abort')) {
+        return false;
+      }
+      _lastErrorMessage =
+          'Unable to load GeoJSON from QR image: ${e.toString()}';
+      _logError('APP', _lastErrorMessage!);
+      notifyListeners();
+      return false;
+    }
+  }
+
   /// 一時GeoJSONファイルを削除します。
   ///
   /// アプリ終了時や新しいQRコードを読み込む際に呼び出されます。
@@ -687,5 +728,27 @@ class AppController extends ChangeNotifier {
     final normalized = (bearing % 360 + 360) % 360;
     final index = ((normalized + 22.5) ~/ 45) % labels.length;
     return labels[index];
+  }
+}
+
+Future<String?> _defaultQrImageAnalyzer(String imagePath) async {
+  final controller = MobileScannerController(
+    autoStart: false,
+    formats: const [BarcodeFormat.qrCode],
+  );
+  try {
+    final capture = await controller.analyzeImage(
+      imagePath,
+      formats: const [BarcodeFormat.qrCode],
+    );
+    for (final barcode in capture?.barcodes ?? const <Barcode>[]) {
+      final rawValue = barcode.rawValue;
+      if (rawValue != null && rawValue.trim().isNotEmpty) {
+        return rawValue;
+      }
+    }
+    return null;
+  } finally {
+    await controller.dispose();
   }
 }

--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -290,9 +290,10 @@ class AppController extends ChangeNotifier {
     await stopMonitoring();
 
     try {
-      // QRテキストがgjb1:で始まることを確認
-      if (!qrText.startsWith('gjb1:')) {
-        _lastErrorMessage = 'Invalid QR code format. Expected gjb1: scheme.';
+      // QRテキストが対応スキームで始まることを確認
+      if (!isSupportedGeoJsonQrText(qrText)) {
+        _lastErrorMessage =
+            'Invalid QR code format. Expected gjb1: or gjz1: scheme.';
         _logError('APP', _lastErrorMessage!);
         notifyListeners();
         return false;

--- a/lib/io/file_manager.dart
+++ b/lib/io/file_manager.dart
@@ -40,11 +40,7 @@ class FileManager {
 
   /// GeoJSONファイルを選択するファイルピッカーを開きます。
   Future<XFile?> pickGeoJsonFile() async {
-    const XTypeGroup typeGroup = XTypeGroup(
-      label: 'GeoJSON files',
-      extensions: ['geojson', 'json', 'bin'],
-    );
-    return await _pickFile(acceptedTypeGroups: [typeGroup]);
+    return await _pickFile();
   }
 
   /// 設定ファイルのパスを取得します。

--- a/lib/io/file_manager.dart
+++ b/lib/io/file_manager.dart
@@ -43,6 +43,19 @@ class FileManager {
     return await _pickFile();
   }
 
+  /// QRコード画像ファイルを選択するファイルピッカーを開きます。
+  Future<XFile?> pickQrImageFile() async {
+    return await _pickFile(
+      acceptedTypeGroups: const [
+        XTypeGroup(
+          label: 'QR code image',
+          extensions: ['png', 'jpg', 'jpeg', 'webp'],
+          mimeTypes: ['image/png', 'image/jpeg', 'image/webp'],
+        ),
+      ],
+    );
+  }
+
   /// 設定ファイルのパスを取得します。
   ///
   /// ファイルが存在しない場合はデフォルト設定で作成します。

--- a/lib/qr/geojson_qr_codec.dart
+++ b/lib/qr/geojson_qr_codec.dart
@@ -12,6 +12,7 @@ import 'package:qr/qr.dart';
 class GeoJsonQrEncodeInput {
   const GeoJsonQrEncodeInput({
     required this.geoJson,
+    this.scheme = GeoJsonQrScheme.gjb1,
     this.enableHash = true,
     this.maxQrTextLength = 2500,
     this.eccLevel = QrErrorCorrectionLevel.quartile,
@@ -23,6 +24,7 @@ class GeoJsonQrEncodeInput {
         assert(quietZoneModules >= 0, 'quietZoneModules must be >= 0');
 
   final String geoJson;
+  final GeoJsonQrScheme scheme;
   final bool enableHash;
   final int maxQrTextLength;
   final QrErrorCorrectionLevel eccLevel;
@@ -134,16 +136,41 @@ enum QrErrorCorrectionLevel {
   high,
 }
 
+/// GeoJSON QRで使う圧縮/ペイロードスキーム。
+enum GeoJsonQrScheme {
+  /// Brotli圧縮。既存互換だが、生成には外部Brotli CLIが必要。
+  gjb1,
+
+  /// gzip圧縮。Dart標準ライブラリのみで生成/復元できる。
+  gjz1,
+}
+
+extension GeoJsonQrSchemeName on GeoJsonQrScheme {
+  String get wireName {
+    switch (this) {
+      case GeoJsonQrScheme.gjb1:
+        return 'gjb1';
+      case GeoJsonQrScheme.gjz1:
+        return 'gjz1';
+    }
+  }
+
+  String get _singlePrefix => wireName;
+  String get _chunkPrefix => '${wireName}p';
+}
+
 /// GeoJSON文字列をQRテキスト(とPNG)へ変換する。
 Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
   final minifyResult = minifyGeoJson(input.geoJson);
   final minimizedBytes =
       Uint8List.fromList(utf8.encode(minifyResult.minimized));
-  final compressedBytes = await brotliCompress(minimizedBytes);
+  final compressedBytes =
+      await _compressForScheme(input.scheme, minimizedBytes);
   final payload = base64UrlEncodeNoPad(compressedBytes);
   final hashHex = input.enableHash ? computeSha256Hex(minimizedBytes) : null;
 
-  var qrTexts = _buildQrTexts(payload, hashHex, input.maxQrTextLength);
+  var qrTexts =
+      _buildQrTexts(input.scheme, payload, hashHex, input.maxQrTextLength);
   var pngImages = <Uint8List>[];
 
   if (input.generatePng) {
@@ -163,7 +190,8 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
       } on PayloadTooLargeException catch (e) {
         if (qrTexts.length == 1 && !retriedSplit) {
           retriedSplit = true;
-          qrTexts = buildGjB1pTexts(
+          qrTexts = _buildChunkedTexts(
+            input.scheme,
             payload,
             hash: hashHex,
             maxLength: input.maxQrTextLength,
@@ -184,6 +212,11 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
   );
 }
 
+bool isSupportedGeoJsonQrText(String text) {
+  final normalized = text.trim();
+  return normalized.startsWith('gjb1:') || normalized.startsWith('gjz1:');
+}
+
 /// QRテキストからGeoJSON文字列を復元する。
 Future<String> decodeGeoJson(GeoJsonQrDecodeInput input) async {
   final normalized = input.qrTexts
@@ -195,9 +228,9 @@ Future<String> decodeGeoJson(GeoJsonQrDecodeInput input) async {
     throw UnsupportedSchemeException('No QR text supplied');
   }
 
-  final payload = _parseGjB1Payload(normalized);
+  final payload = _parseQrPayload(normalized);
   final compressedBytes = base64UrlDecodeNoPad(payload.payload);
-  final minimizedBytes = brotliDecompress(compressedBytes);
+  final minimizedBytes = _decompressForScheme(payload.scheme, compressedBytes);
   final minimized = utf8.decode(minimizedBytes);
 
   validateGeoJsonStructure(jsonDecode(minimized));
@@ -311,6 +344,14 @@ Future<Uint8List> brotliCompress(Uint8List bytes, {int quality = 11}) async {
   }
 }
 
+Uint8List gzipCompress(Uint8List bytes, {int level = 9}) {
+  try {
+    return Uint8List.fromList(GZipCodec(level: level).encode(bytes));
+  } catch (e) {
+    throw CompressFailedException('gzip compression failed', e);
+  }
+}
+
 Uint8List brotliDecompress(Uint8List bytes) {
   try {
     const decoder = brotli.BrotliDecoder();
@@ -318,6 +359,14 @@ Uint8List brotliDecompress(Uint8List bytes) {
     return Uint8List.fromList(decompressed);
   } catch (e) {
     throw DecompressFailedException('Brotli decompression failed', e);
+  }
+}
+
+Uint8List gzipDecompress(Uint8List bytes) {
+  try {
+    return Uint8List.fromList(GZipCodec().decode(bytes));
+  } catch (e) {
+    throw DecompressFailedException('gzip decompression failed', e);
   }
 }
 
@@ -344,19 +393,51 @@ Uint8List base64UrlDecodeNoPad(String text) {
 
 String computeSha256Hex(Uint8List bytes) => sha256.convert(bytes).toString();
 
-List<String> _buildQrTexts(String payload, String? hashHex, int maxLength) {
-  final single = _buildGjB1Text(payload, hashHex);
+Future<Uint8List> _compressForScheme(
+  GeoJsonQrScheme scheme,
+  Uint8List bytes,
+) {
+  switch (scheme) {
+    case GeoJsonQrScheme.gjb1:
+      return brotliCompress(bytes);
+    case GeoJsonQrScheme.gjz1:
+      return Future.value(gzipCompress(bytes));
+  }
+}
+
+Uint8List _decompressForScheme(GeoJsonQrScheme scheme, Uint8List bytes) {
+  switch (scheme) {
+    case GeoJsonQrScheme.gjb1:
+      return brotliDecompress(bytes);
+    case GeoJsonQrScheme.gjz1:
+      return gzipDecompress(bytes);
+  }
+}
+
+List<String> _buildQrTexts(
+  GeoJsonQrScheme scheme,
+  String payload,
+  String? hashHex,
+  int maxLength,
+) {
+  final single = _buildSingleText(scheme, payload, hashHex);
   if (single.length <= maxLength) {
     return [single];
   }
-  return buildGjB1pTexts(payload, hash: hashHex, maxLength: maxLength);
+  return _buildChunkedTexts(scheme, payload,
+      hash: hashHex, maxLength: maxLength);
 }
 
-String _buildGjB1Text(String payload, String? hashHex) {
+String _buildSingleText(
+  GeoJsonQrScheme scheme,
+  String payload,
+  String? hashHex,
+) {
+  final prefix = scheme._singlePrefix;
   if (hashHex == null) {
-    return 'gjb1:$payload';
+    return '$prefix:$payload';
   }
-  return 'gjb1:$payload#$hashHex';
+  return '$prefix:$payload#$hashHex';
 }
 
 List<String> buildGjB1pTexts(
@@ -364,6 +445,34 @@ List<String> buildGjB1pTexts(
   String? hash,
   required int maxLength,
 }) {
+  return _buildChunkedTexts(
+    GeoJsonQrScheme.gjb1,
+    payload,
+    hash: hash,
+    maxLength: maxLength,
+  );
+}
+
+List<String> buildGjZ1pTexts(
+  String payload, {
+  String? hash,
+  required int maxLength,
+}) {
+  return _buildChunkedTexts(
+    GeoJsonQrScheme.gjz1,
+    payload,
+    hash: hash,
+    maxLength: maxLength,
+  );
+}
+
+List<String> _buildChunkedTexts(
+  GeoJsonQrScheme scheme,
+  String payload, {
+  String? hash,
+  required int maxLength,
+}) {
+  final chunkPrefix = scheme._chunkPrefix;
   if (maxLength <= 12) {
     throw PayloadTooLargeException(
         'maxQrTextLength too small to hold metadata');
@@ -375,7 +484,8 @@ List<String> buildGjB1pTexts(
     final digitsTotal = _digits(total);
     final maxChunkPayloadLength = maxLength - (8 + 2 * digitsTotal);
     if (maxChunkPayloadLength <= 0) {
-      throw PayloadTooLargeException('maxQrTextLength too small for gjb1p');
+      throw PayloadTooLargeException(
+          'maxQrTextLength too small for $chunkPrefix');
     }
 
     final chunks = <String>[];
@@ -411,44 +521,59 @@ List<String> buildGjB1pTexts(
     final result = <String>[];
     for (var i = 0; i < chunks.length; i++) {
       final indexStr = (i + 1).toString();
-      result.add('gjb1p:$indexStr/$totalStr:${chunks[i]}');
+      result.add('$chunkPrefix:$indexStr/$totalStr:${chunks[i]}');
     }
     return result;
   }
 }
 
-/// `gjb1` / `gjb1p`テキストを解析してペイロードとハッシュを取り出す。
-GjB1Payload _parseGjB1Payload(List<String> texts) {
-  if (texts.length == 1 && texts.first.startsWith('gjb1:')) {
-    return _parseGjB1Single(texts.first);
+/// `gjb1` / `gjb1p` / `gjz1` / `gjz1p`テキストを解析する。
+QrPayload _parseQrPayload(List<String> texts) {
+  if (texts.length == 1) {
+    final text = texts.first;
+    if (text.startsWith('gjb1:')) {
+      return _parseSinglePayload(GeoJsonQrScheme.gjb1, text);
+    }
+    if (text.startsWith('gjz1:')) {
+      return _parseSinglePayload(GeoJsonQrScheme.gjz1, text);
+    }
   }
+
   if (texts.every((element) => element.startsWith('gjb1p:'))) {
-    final merged = _mergeGjB1Chunks(texts);
-    return _parseGjB1Single('gjb1:$merged');
+    final merged = _mergeChunks(texts, GeoJsonQrScheme.gjb1);
+    return _parseSinglePayload(GeoJsonQrScheme.gjb1, 'gjb1:$merged');
+  }
+  if (texts.every((element) => element.startsWith('gjz1p:'))) {
+    final merged = _mergeChunks(texts, GeoJsonQrScheme.gjz1);
+    return _parseSinglePayload(GeoJsonQrScheme.gjz1, 'gjz1:$merged');
   }
   throw UnsupportedSchemeException('Unsupported QR scheme');
 }
 
-GjB1Payload _parseGjB1Single(String text) {
-  if (!text.startsWith('gjb1:')) {
-    throw UnsupportedSchemeException('Expected gjb1 scheme');
+QrPayload _parseSinglePayload(GeoJsonQrScheme scheme, String text) {
+  final prefix = scheme._singlePrefix;
+  if (!text.startsWith('$prefix:')) {
+    throw UnsupportedSchemeException('Expected $prefix scheme');
   }
-  final payloadWithHash = text.substring('gjb1:'.length);
+  final payloadWithHash = text.substring(prefix.length + 1);
   if (payloadWithHash.isEmpty) {
-    throw DecodeFailedException('Empty gjb1 payload');
+    throw DecodeFailedException('Empty $prefix payload');
   }
-  return _splitPayloadAndHash(payloadWithHash);
+  final split = _splitPayloadAndHash(payloadWithHash);
+  return QrPayload(scheme, split.payload, split.hashHex);
 }
 
-String _mergeGjB1Chunks(List<String> texts) {
-  final chunkRegExp = RegExp(r'^gjb1p:(\d+)/(\d+):(.*)$', dotAll: true);
+String _mergeChunks(List<String> texts, GeoJsonQrScheme scheme) {
+  final chunkPrefix = scheme._chunkPrefix;
+  final chunkRegExp =
+      RegExp('^$chunkPrefix:(\\d+)/(\\d+):(.*)\$', dotAll: true);
   final Map<int, String> chunks = {};
   int? expectedTotal;
 
   for (final text in texts) {
     final match = chunkRegExp.firstMatch(text);
     if (match == null) {
-      throw UnsupportedSchemeException('Malformed gjb1p chunk');
+      throw UnsupportedSchemeException('Malformed $chunkPrefix chunk');
     }
     final index = int.parse(match.group(1)!);
     final total = int.parse(match.group(2)!);
@@ -481,10 +606,10 @@ String _mergeGjB1Chunks(List<String> texts) {
   return buffer.toString();
 }
 
-GjB1Payload _splitPayloadAndHash(String payloadWithHash) {
+PayloadAndHash _splitPayloadAndHash(String payloadWithHash) {
   final hashIndex = payloadWithHash.lastIndexOf('#');
   if (hashIndex == -1) {
-    return GjB1Payload(payloadWithHash, null);
+    return PayloadAndHash(payloadWithHash, null);
   }
 
   final payload = payloadWithHash.substring(0, hashIndex);
@@ -494,12 +619,20 @@ GjB1Payload _splitPayloadAndHash(String payloadWithHash) {
     throw DecodeFailedException('Malformed hash suffix');
   }
 
-  return GjB1Payload(payload, hash);
+  return PayloadAndHash(payload, hash);
 }
 
-class GjB1Payload {
-  const GjB1Payload(this.payload, this.hashHex);
+class PayloadAndHash {
+  const PayloadAndHash(this.payload, this.hashHex);
 
+  final String payload;
+  final String? hashHex;
+}
+
+class QrPayload {
+  const QrPayload(this.scheme, this.payload, this.hashHex);
+
+  final GeoJsonQrScheme scheme;
   final String payload;
   final String? hashHex;
 }

--- a/lib/qr/geojson_qr_codec.dart
+++ b/lib/qr/geojson_qr_codec.dart
@@ -433,9 +433,13 @@ QrPayload _parseQrPayload(List<String> texts) {
 
 QrPayload _parseSinglePayload(GeoJsonQrScheme scheme, String text) {
   final prefix = scheme._singlePrefix;
+  // coverage:ignore-start
+  // _parseQrPayload routes by prefix before calling this helper, so this guard
+  // is defensive against future private misuse rather than public behavior.
   if (!text.startsWith('$prefix:')) {
     throw UnsupportedSchemeException('Expected $prefix scheme');
   }
+  // coverage:ignore-end
   final payloadWithHash = text.substring(prefix.length + 1);
   if (payloadWithHash.isEmpty) {
     throw DecodeFailedException('Empty $prefix payload');

--- a/lib/qr/geojson_qr_codec.dart
+++ b/lib/qr/geojson_qr_codec.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:brotli/brotli.dart' as brotli;
@@ -60,9 +59,6 @@ class GeoJsonQrBundle {
   final String minimizedGeoJson;
   final String? hashHex;
   final GeoJsonInfo info;
-
-  int get chunkCount => qrTexts.length;
-  bool get isSplit => qrTexts.length > 1;
 }
 
 /// GeoJSONの概要情報。
@@ -110,10 +106,6 @@ class UnsupportedSchemeException extends GeoJsonQrException {
       : super('E_UNSUPPORTED_SCHEME', message);
 }
 
-class ChunkMismatchException extends GeoJsonQrException {
-  ChunkMismatchException(String message) : super('E_CHUNK_MISMATCH', message);
-}
-
 class HashMismatchException extends GeoJsonQrException {
   HashMismatchException(String message) : super('E_HASH_MISMATCH', message);
 }
@@ -156,7 +148,6 @@ extension GeoJsonQrSchemeName on GeoJsonQrScheme {
   }
 
   String get _singlePrefix => wireName;
-  String get _chunkPrefix => '${wireName}p';
 }
 
 /// GeoJSON文字列をQRテキスト(とPNG)へ変換する。
@@ -174,32 +165,17 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
   var pngImages = <Uint8List>[];
 
   if (input.generatePng) {
-    var retriedSplit = false;
-    while (true) {
-      try {
-        pngImages = [
-          for (final text in qrTexts)
-            generateQrPng(
-              text,
-              input.eccLevel,
-              modulePixelSize: input.modulePixelSize,
-              quietZoneModules: input.quietZoneModules,
-            ),
-        ];
-        break;
-      } on PayloadTooLargeException catch (e) {
-        if (qrTexts.length == 1 && !retriedSplit) {
-          retriedSplit = true;
-          qrTexts = _buildChunkedTexts(
-            input.scheme,
-            payload,
-            hash: hashHex,
-            maxLength: input.maxQrTextLength,
-          );
-          continue;
-        }
-        throw QrGenerationException(e.message, e);
-      }
+    try {
+      pngImages = [
+        generateQrPng(
+          qrTexts.single,
+          input.eccLevel,
+          modulePixelSize: input.modulePixelSize,
+          quietZoneModules: input.quietZoneModules,
+        ),
+      ];
+    } on PayloadTooLargeException catch (e) {
+      throw QrGenerationException(e.message, e);
     }
   }
 
@@ -424,8 +400,8 @@ List<String> _buildQrTexts(
   if (single.length <= maxLength) {
     return [single];
   }
-  return _buildChunkedTexts(scheme, payload,
-      hash: hashHex, maxLength: maxLength);
+  throw PayloadTooLargeException(
+      'QR payload too large for maxQrTextLength: $maxLength');
 }
 
 String _buildSingleText(
@@ -440,94 +416,7 @@ String _buildSingleText(
   return '$prefix:$payload#$hashHex';
 }
 
-List<String> buildGjB1pTexts(
-  String payload, {
-  String? hash,
-  required int maxLength,
-}) {
-  return _buildChunkedTexts(
-    GeoJsonQrScheme.gjb1,
-    payload,
-    hash: hash,
-    maxLength: maxLength,
-  );
-}
-
-List<String> buildGjZ1pTexts(
-  String payload, {
-  String? hash,
-  required int maxLength,
-}) {
-  return _buildChunkedTexts(
-    GeoJsonQrScheme.gjz1,
-    payload,
-    hash: hash,
-    maxLength: maxLength,
-  );
-}
-
-List<String> _buildChunkedTexts(
-  GeoJsonQrScheme scheme,
-  String payload, {
-  String? hash,
-  required int maxLength,
-}) {
-  final chunkPrefix = scheme._chunkPrefix;
-  if (maxLength <= 12) {
-    throw PayloadTooLargeException(
-        'maxQrTextLength too small to hold metadata');
-  }
-  final payloadWithHash = hash == null ? payload : '$payload#$hash';
-  var total = max(1, (payloadWithHash.length / (maxLength - 12)).ceil());
-
-  while (true) {
-    final digitsTotal = _digits(total);
-    final maxChunkPayloadLength = maxLength - (8 + 2 * digitsTotal);
-    if (maxChunkPayloadLength <= 0) {
-      throw PayloadTooLargeException(
-          'maxQrTextLength too small for $chunkPrefix');
-    }
-
-    final chunks = <String>[];
-    var offset = 0;
-    while (offset < payloadWithHash.length) {
-      final end = min(offset + maxChunkPayloadLength, payloadWithHash.length);
-      chunks.add(payloadWithHash.substring(offset, end));
-      offset = end;
-    }
-
-    if (chunks.length != total) {
-      total = chunks.length;
-      continue;
-    }
-
-    final totalStr = total.toString();
-    var overflow = false;
-    for (var i = 0; i < chunks.length; i++) {
-      final indexStr = (i + 1).toString();
-      final projectedLength =
-          6 + indexStr.length + 1 + totalStr.length + 1 + chunks[i].length;
-      if (projectedLength > maxLength) {
-        overflow = true;
-        break;
-      }
-    }
-
-    if (overflow) {
-      total += 1;
-      continue;
-    }
-
-    final result = <String>[];
-    for (var i = 0; i < chunks.length; i++) {
-      final indexStr = (i + 1).toString();
-      result.add('$chunkPrefix:$indexStr/$totalStr:${chunks[i]}');
-    }
-    return result;
-  }
-}
-
-/// `gjb1` / `gjb1p` / `gjz1` / `gjz1p`テキストを解析する。
+/// `gjb1` / `gjz1`テキストを解析する。
 QrPayload _parseQrPayload(List<String> texts) {
   if (texts.length == 1) {
     final text = texts.first;
@@ -539,14 +428,6 @@ QrPayload _parseQrPayload(List<String> texts) {
     }
   }
 
-  if (texts.every((element) => element.startsWith('gjb1p:'))) {
-    final merged = _mergeChunks(texts, GeoJsonQrScheme.gjb1);
-    return _parseSinglePayload(GeoJsonQrScheme.gjb1, 'gjb1:$merged');
-  }
-  if (texts.every((element) => element.startsWith('gjz1p:'))) {
-    final merged = _mergeChunks(texts, GeoJsonQrScheme.gjz1);
-    return _parseSinglePayload(GeoJsonQrScheme.gjz1, 'gjz1:$merged');
-  }
   throw UnsupportedSchemeException('Unsupported QR scheme');
 }
 
@@ -561,49 +442,6 @@ QrPayload _parseSinglePayload(GeoJsonQrScheme scheme, String text) {
   }
   final split = _splitPayloadAndHash(payloadWithHash);
   return QrPayload(scheme, split.payload, split.hashHex);
-}
-
-String _mergeChunks(List<String> texts, GeoJsonQrScheme scheme) {
-  final chunkPrefix = scheme._chunkPrefix;
-  final chunkRegExp =
-      RegExp('^$chunkPrefix:(\\d+)/(\\d+):(.*)\$', dotAll: true);
-  final Map<int, String> chunks = {};
-  int? expectedTotal;
-
-  for (final text in texts) {
-    final match = chunkRegExp.firstMatch(text);
-    if (match == null) {
-      throw UnsupportedSchemeException('Malformed $chunkPrefix chunk');
-    }
-    final index = int.parse(match.group(1)!);
-    final total = int.parse(match.group(2)!);
-    final payload = match.group(3)!;
-
-    if (index < 1 || total < 1) {
-      throw ChunkMismatchException('Chunk index/total must be positive');
-    }
-    expectedTotal ??= total;
-    if (expectedTotal != total) {
-      throw ChunkMismatchException('Inconsistent total count in chunks');
-    }
-    if (chunks.containsKey(index)) {
-      throw ChunkMismatchException('Duplicate chunk index: $index');
-    }
-    chunks[index] = payload;
-  }
-
-  final total = expectedTotal ?? chunks.length;
-  for (var i = 1; i <= total; i++) {
-    if (!chunks.containsKey(i)) {
-      throw ChunkMismatchException('Missing chunk index: $i');
-    }
-  }
-
-  final buffer = StringBuffer();
-  for (var i = 1; i <= total; i++) {
-    buffer.write(chunks[i]);
-  }
-  return buffer.toString();
 }
 
 PayloadAndHash _splitPayloadAndHash(String payloadWithHash) {
@@ -779,8 +617,6 @@ bool _isValidHashHex(String value) {
   final hashRegExp = RegExp(r'^[0-9a-fA-F]{64}$');
   return hashRegExp.hasMatch(value);
 }
-
-int _digits(int value) => max(1, value.toString().length);
 
 bool _constantTimeEquals(String a, String b) {
   if (a.length != b.length) {

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -7,6 +7,7 @@ import '../io/log_entry.dart';
 import '../state_machine/state.dart';
 import 'background_location_disclosure_page.dart';
 import 'monitoring_permission_card.dart';
+import 'qr_generator_page.dart';
 import 'qr_scanner_page.dart';
 import 'settings_page.dart';
 
@@ -476,11 +477,16 @@ class _OverflowMenu extends StatelessWidget {
     return PopupMenuButton<int>(
       itemBuilder: (context) => const [
         PopupMenuItem(value: 1, child: Text('Settings')),
+        PopupMenuItem(value: 2, child: Text('Generate QR code')),
       ],
       onSelected: (value) {
         if (value == 1) {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (_) => const SettingsPage()),
+          );
+        } else if (value == 2) {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const QrGeneratorPage()),
           );
         }
       },

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -11,6 +11,11 @@ import 'qr_generator_page.dart';
 import 'qr_scanner_page.dart';
 import 'settings_page.dart';
 
+enum _LoadFileAction {
+  geoJson,
+  qrImage,
+}
+
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
@@ -109,8 +114,9 @@ class HomePage extends StatelessWidget {
                                   isWaitStart: snapshot.status ==
                                       LocationStateStatus.waitStart,
                                   geoJsonReady: controller.geoJsonLoaded,
-                                  onLoadGeoJson:
-                                      controller.reloadGeoJsonFromPicker,
+                                  onLoadFile: () {
+                                    _showLoadFileSheet(context, controller);
+                                  },
                                   onOpenQr: () {
                                     Navigator.of(context).push(
                                       MaterialPageRoute(
@@ -242,6 +248,8 @@ class HomePage extends StatelessWidget {
                             ),
                           ),
                         ),
+                        const SizedBox(height: 12),
+                        const _CreditFooter(),
                       ],
                     )
                   : Column(
@@ -290,8 +298,9 @@ class HomePage extends StatelessWidget {
                                     isWaitStart: snapshot.status ==
                                         LocationStateStatus.waitStart,
                                     geoJsonReady: controller.geoJsonLoaded,
-                                    onLoadGeoJson:
-                                        controller.reloadGeoJsonFromPicker,
+                                    onLoadFile: () {
+                                      _showLoadFileSheet(context, controller);
+                                    },
                                     onOpenQr: () {
                                       Navigator.of(context).push(
                                         MaterialPageRoute(
@@ -335,7 +344,8 @@ class HomePage extends StatelessWidget {
                             ),
                           ),
                         ),
-                        // エラー表示はSnackbarに移行済み
+                        const SizedBox(height: 12),
+                        const _CreditFooter(),
                       ],
                     ),
             ),
@@ -344,6 +354,49 @@ class HomePage extends StatelessWidget {
         );
       },
     );
+  }
+}
+
+Future<void> _showLoadFileSheet(
+  BuildContext context,
+  AppController controller,
+) async {
+  final action = await showModalBottomSheet<_LoadFileAction>(
+    context: context,
+    builder: (context) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.map),
+              title: const Text('GeoJSONファイルを読み込む'),
+              onTap: () {
+                Navigator.of(context).pop(_LoadFileAction.geoJson);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.image_search),
+              title: const Text('QRコード画像を読み込む'),
+              onTap: () {
+                Navigator.of(context).pop(_LoadFileAction.qrImage);
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+
+  switch (action) {
+    case _LoadFileAction.geoJson:
+      await controller.reloadGeoJsonFromPicker();
+      return;
+    case _LoadFileAction.qrImage:
+      await controller.reloadGeoJsonFromQrImagePicker();
+      return;
+    case null:
+      return;
   }
 }
 
@@ -430,13 +483,13 @@ class _BottomActions extends StatelessWidget {
   const _BottomActions({
     required this.isWaitStart,
     required this.geoJsonReady,
-    required this.onLoadGeoJson,
+    required this.onLoadFile,
     required this.onOpenQr,
   });
 
   final bool isWaitStart;
   final bool geoJsonReady;
-  final VoidCallback onLoadGeoJson;
+  final VoidCallback onLoadFile;
   final VoidCallback onOpenQr;
 
   @override
@@ -449,9 +502,12 @@ class _BottomActions extends StatelessWidget {
           children: [
             Expanded(
               child: OutlinedButton.icon(
-                onPressed: onLoadGeoJson,
-                icon: const Icon(Icons.map),
-                label: const Text('Load GeoJSON'),
+                onPressed: onLoadFile,
+                icon: const Icon(Icons.folder_open),
+                label: const Text(
+                  'ファイルを\n読み込む',
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
             const SizedBox(width: 12),
@@ -459,12 +515,30 @@ class _BottomActions extends StatelessWidget {
               child: OutlinedButton.icon(
                 onPressed: onOpenQr,
                 icon: const Icon(Icons.qr_code_scanner),
-                label: const Text('Read QR code'),
+                label: const Text(
+                  'QRコードを\n読み込む',
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
           ],
         ),
       ],
+    );
+  }
+}
+
+class _CreditFooter extends StatelessWidget {
+  const _CreditFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'created by Kaito YAMADA',
+      textAlign: TextAlign.center,
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
     );
   }
 }

--- a/lib/ui/qr_generator_page.dart
+++ b/lib/ui/qr_generator_page.dart
@@ -1,0 +1,478 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart' as fs;
+import 'package:flutter/material.dart';
+import 'package:gal/gal.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../qr/geojson_qr_codec.dart';
+
+typedef GeoJsonQrEncoder = Future<GeoJsonQrBundle> Function(
+  GeoJsonQrEncodeInput input,
+);
+typedef GeoJsonFilePicker = Future<fs.XFile?> Function();
+typedef QrGallerySaver = Future<void> Function(Uint8List bytes, String name);
+typedef QrShareHandler = Future<void> Function(
+  Uint8List bytes,
+  String fileName,
+  BuildContext context,
+);
+
+class QrGeneratorPage extends StatefulWidget {
+  const QrGeneratorPage({
+    super.key,
+    this.filePicker,
+    this.encoder = encodeGeoJson,
+    this.gallerySaver = _saveQrToGallery,
+    this.shareHandler = _shareQrImage,
+  });
+
+  final GeoJsonFilePicker? filePicker;
+  final GeoJsonQrEncoder encoder;
+  final QrGallerySaver gallerySaver;
+  final QrShareHandler shareHandler;
+
+  @override
+  State<QrGeneratorPage> createState() => _QrGeneratorPageState();
+}
+
+class _QrGeneratorPageState extends State<QrGeneratorPage> {
+  bool _isGenerating = false;
+  bool _isSaving = false;
+  bool _isSharing = false;
+  String? _errorMessage;
+  _GeneratedQr? _generatedQr;
+
+  bool get _hasSingleQr => _generatedQr != null;
+
+  Future<void> _selectAndGenerate() async {
+    setState(() {
+      _isGenerating = true;
+      _errorMessage = null;
+      _generatedQr = null;
+    });
+
+    try {
+      final selected = await (widget.filePicker ?? _pickGeoJsonFile)();
+      if (!mounted) {
+        return;
+      }
+      if (selected == null) {
+        setState(() {
+          _isGenerating = false;
+        });
+        return;
+      }
+
+      final rawGeoJson = await selected.readAsString();
+      final bundle = await widget.encoder(
+        GeoJsonQrEncodeInput(
+          geoJson: rawGeoJson,
+          scheme: GeoJsonQrScheme.gjz1,
+          enableHash: true,
+          maxQrTextLength: 2500,
+          eccLevel: QrErrorCorrectionLevel.quartile,
+          generatePng: true,
+          modulePixelSize: 8,
+          quietZoneModules: 4,
+        ),
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      if (bundle.isSplit || bundle.pngImages.length != 1) {
+        setState(() {
+          _isGenerating = false;
+          _errorMessage = '1枚のQRに収まりません。GeoJSONを簡略化してください。';
+        });
+        return;
+      }
+
+      setState(() {
+        _isGenerating = false;
+        _generatedQr = _GeneratedQr(
+          fileName: _displayFileName(selected),
+          imageBytes: bundle.pngImages.single,
+          info: bundle.info,
+          schemeLabel: _schemeLabel(bundle.qrTexts.single),
+          hashHex: bundle.hashHex,
+          minimizedBytes: bundle.minimizedGeoJson.length,
+          qrTextBytes: bundle.qrTexts.single.length,
+        );
+      });
+    } on GeoJsonQrException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isGenerating = false;
+        _errorMessage = 'QRコードの生成に失敗しました: ${e.message}';
+      });
+    } on FormatException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isGenerating = false;
+        _errorMessage = 'GeoJSONの形式が正しくありません: ${e.message}';
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isGenerating = false;
+        _errorMessage = 'QRコードの生成中にエラーが発生しました: $e';
+      });
+    }
+  }
+
+  Future<void> _saveQr() async {
+    final generated = _generatedQr;
+    if (generated == null || _isSaving) {
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+    });
+    try {
+      await widget.gallerySaver(
+        generated.imageBytes,
+        generated.outputBaseName,
+      );
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('写真に保存しました')),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('保存に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _shareQr() async {
+    final generated = _generatedQr;
+    if (generated == null || _isSharing) {
+      return;
+    }
+
+    setState(() {
+      _isSharing = true;
+    });
+    try {
+      await widget.shareHandler(
+        generated.imageBytes,
+        '${generated.outputBaseName}.png',
+        context,
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('共有に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSharing = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final generated = _generatedQr;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Generate QR code'),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            FilledButton.icon(
+              onPressed: _isGenerating ? null : _selectAndGenerate,
+              icon: _isGenerating
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.upload_file),
+              label: Text(_isGenerating ? '生成中...' : 'GeoJSONを選択'),
+            ),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 16),
+              _ErrorPanel(message: _errorMessage!),
+            ],
+            if (generated != null) ...[
+              const SizedBox(height: 20),
+              _QrPreview(generated: generated),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: _hasSingleQr && !_isSaving ? _saveQr : null,
+                      icon: _isSaving
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.save_alt),
+                      label: const Text('保存'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _hasSingleQr && !_isSharing ? _shareQr : null,
+                      icon: _isSharing
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.ios_share),
+                      label: const Text('共有'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QrPreview extends StatelessWidget {
+  const _QrPreview({required this.generated});
+
+  final _GeneratedQr generated;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hash = generated.hashHex;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: theme.colorScheme.outlineVariant),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: Image.memory(
+                  generated.imageBytes,
+                  key: const ValueKey('generated_qr_image'),
+                  fit: BoxFit.contain,
+                  gaplessPlayback: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        _InfoRow(label: 'ファイル名', value: generated.fileName),
+        _InfoRow(label: 'スキーム', value: generated.schemeLabel),
+        _InfoRow(label: 'GeoJSONタイプ', value: generated.info.type),
+        if (generated.info.featureCount != null)
+          _InfoRow(
+            label: 'フィーチャ数',
+            value: generated.info.featureCount.toString(),
+          ),
+        _InfoRow(label: '最小化サイズ', value: '${generated.minimizedBytes} bytes'),
+        _InfoRow(label: 'QRテキスト長', value: '${generated.qrTextBytes} chars'),
+        if (hash != null)
+          _InfoRow(
+            label: 'ハッシュ',
+            value: hash,
+            monospace: true,
+          ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.label,
+    required this.value,
+    this.monospace = false,
+  });
+
+  final String label;
+  final String value;
+  final bool monospace;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 116,
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontFamily: monospace ? 'monospace' : null,
+                height: 1.25,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorPanel extends StatelessWidget {
+  const _ErrorPanel({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.errorContainer,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.error_outline, color: theme.colorScheme.error),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GeneratedQr {
+  const _GeneratedQr({
+    required this.fileName,
+    required this.imageBytes,
+    required this.info,
+    required this.schemeLabel,
+    required this.hashHex,
+    required this.minimizedBytes,
+    required this.qrTextBytes,
+  });
+
+  final String fileName;
+  final Uint8List imageBytes;
+  final GeoJsonInfo info;
+  final String schemeLabel;
+  final String? hashHex;
+  final int minimizedBytes;
+  final int qrTextBytes;
+
+  String get outputBaseName {
+    final withoutExtension = path.basenameWithoutExtension(fileName);
+    final normalized =
+        withoutExtension.replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '_');
+    final safeName = normalized.isEmpty ? 'geojson' : normalized;
+    return 'argus_qr_$safeName';
+  }
+}
+
+Future<fs.XFile?> _pickGeoJsonFile() {
+  return fs.openFile();
+}
+
+Future<void> _saveQrToGallery(Uint8List bytes, String name) async {
+  var hasAccess = await Gal.hasAccess();
+  if (!hasAccess) {
+    hasAccess = await Gal.requestAccess();
+  }
+  if (!hasAccess) {
+    throw Exception('写真へのアクセスが許可されていません。');
+  }
+  await Gal.putImageBytes(bytes, name: name);
+}
+
+Future<void> _shareQrImage(
+  Uint8List bytes,
+  String fileName,
+  BuildContext context,
+) async {
+  final box = context.findRenderObject() as RenderBox?;
+  final tempDir = await getTemporaryDirectory();
+  final file = File(path.join(tempDir.path, fileName));
+  await file.writeAsBytes(bytes, flush: true);
+
+  await SharePlus.instance.share(
+    ShareParams(
+      title: 'ARGUS GeoJSON QR code',
+      files: [XFile(file.path, mimeType: 'image/png')],
+      sharePositionOrigin:
+          box == null ? null : box.localToGlobal(Offset.zero) & box.size,
+    ),
+  );
+}
+
+String _displayFileName(fs.XFile file) {
+  if (file.name.isNotEmpty) {
+    return file.name;
+  }
+  return path.basename(file.path);
+}
+
+String _schemeLabel(String qrText) {
+  final separator = qrText.indexOf(':');
+  if (separator <= 0) {
+    return '-';
+  }
+  return qrText.substring(0, separator);
+}

--- a/lib/ui/qr_generator_page.dart
+++ b/lib/ui/qr_generator_page.dart
@@ -427,6 +427,10 @@ class _GeneratedQr {
   }
 }
 
+// coverage:ignore-start
+// These default adapters call platform plugins. Widget tests cover the
+// surrounding behavior by injecting file picker, gallery saver, and share
+// handlers instead of invoking real platform channels.
 Future<fs.XFile?> _pickGeoJsonFile() {
   return fs.openFile();
 }
@@ -461,12 +465,13 @@ Future<void> _shareQrImage(
     ),
   );
 }
+// coverage:ignore-end
 
 String _displayFileName(fs.XFile file) {
   if (file.name.isNotEmpty) {
     return file.name;
   }
-  return path.basename(file.path);
+  return path.basename(file.path); // coverage:ignore-line
 }
 
 String _schemeLabel(String qrText) {

--- a/lib/ui/qr_generator_page.dart
+++ b/lib/ui/qr_generator_page.dart
@@ -85,7 +85,7 @@ class _QrGeneratorPageState extends State<QrGeneratorPage> {
         return;
       }
 
-      if (bundle.isSplit || bundle.pngImages.length != 1) {
+      if (bundle.pngImages.length != 1) {
         setState(() {
           _isGenerating = false;
           _errorMessage = '1枚のQRに収まりません。GeoJSONを簡略化してください。';

--- a/lib/ui/qr_scanner_page.dart
+++ b/lib/ui/qr_scanner_page.dart
@@ -109,7 +109,8 @@ class _QrScannerPageState extends State<QrScannerPage>
       });
     }
 
-    final cameraPermission = await _permissionCoordinator.ensureCameraPermission();
+    final cameraPermission =
+        await _permissionCoordinator.ensureCameraPermission();
     if (!mounted) {
       return;
     }
@@ -171,8 +172,7 @@ class _QrScannerPageState extends State<QrScannerPage>
       }
       setState(() {
         _scannerState = _QrScannerState.error;
-        _errorMessage =
-            'QR スキャナを開始できませんでした。時間をおいて再試行してください。\n$e';
+        _errorMessage = 'QR スキャナを開始できませんでした。時間をおいて再試行してください。\n$e';
       });
     } finally {
       _isStartingScanner = false;
@@ -230,7 +230,7 @@ class _QrScannerPageState extends State<QrScannerPage>
     });
 
     try {
-      if (!qrText.startsWith('gjb1:')) {
+      if (!isSupportedGeoJsonQrText(qrText)) {
         setState(() {
           _errorMessage = 'GeoJSON QR コードではありません。';
           _isProcessing = false;
@@ -245,7 +245,8 @@ class _QrScannerPageState extends State<QrScannerPage>
         Navigator.of(context).pop();
       } else if (mounted && !loaded) {
         setState(() {
-          _errorMessage = appController.lastErrorMessage ?? 'GeoJSON の読込に失敗しました。';
+          _errorMessage =
+              appController.lastErrorMessage ?? 'GeoJSON の読込に失敗しました。';
           _isProcessing = false;
         });
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   vibration: ^2.0.0
   mobile_scanner: ^7.2.0
   url_launcher: ^6.3.2
+  share_plus: ^11.1.0
+  gal: ^2.3.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   build_runner: ^2.4.6
   json_serializable: ^6.7.1
+  path_provider_platform_interface: ^2.1.2
 
 flutter:
   uses-material-design: true

--- a/scripts/geojson_qr_demo.dart
+++ b/scripts/geojson_qr_demo.dart
@@ -42,8 +42,7 @@ Future<void> main(List<String> args) async {
 
     print('エンコード完了:');
     print('  - 最小化されたGeoJSONサイズ: ${bundle.minimizedGeoJson.length} bytes');
-    print('  - QRコードテキスト数: ${bundle.chunkCount}');
-    print('  - 分割QR: ${bundle.isSplit ? "はい" : "いいえ"}');
+    print('  - QRコードテキスト数: ${bundle.qrTexts.length}');
     print('  - ハッシュ: ${bundle.hashHex}');
     print('  - GeoJSONタイプ: ${bundle.info.type}');
     if (bundle.info.featureCount != null) {
@@ -55,7 +54,7 @@ Future<void> main(List<String> args) async {
     for (var i = 0; i < bundle.pngImages.length; i++) {
       final pngPath = path.join(
         outputDir,
-        bundle.chunkCount == 1 ? 'qr.png' : 'qr_${i + 1}.png',
+        'qr.png',
       );
       await File(pngPath).writeAsBytes(bundle.pngImages[i]);
       print('  保存: $pngPath (${bundle.pngImages[i].length} bytes)');

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -16,6 +17,7 @@ import 'package:argus/qr/geojson_qr_codec.dart';
 import 'package:argus/state_machine/state.dart';
 import 'package:argus/state_machine/state_machine.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'support/notifier_fakes.dart';
@@ -216,8 +218,7 @@ void main() {
       expect(controller.config!.alarmVolume, 0.8);
     });
 
-    test('refreshMonitoringPermissionState updates permission state',
-        () async {
+    test('refreshMonitoringPermissionState updates permission state', () async {
       final coordinator = _TrackingPermissionCoordinator(
         refreshState: const MonitoringPermissionState(
           notificationStatus: PermissionStatus.granted,
@@ -240,7 +241,8 @@ void main() {
 
       await controller.refreshMonitoringPermissionState();
 
-      expect(controller.monitoringPermissionState.locationAlwaysGranted, isFalse);
+      expect(
+          controller.monitoringPermissionState.locationAlwaysGranted, isFalse);
       expect(coordinator.refreshCount, 1);
     });
 
@@ -757,6 +759,82 @@ void main() {
       expect(controller.geoJsonLoaded, isFalse);
     });
 
+    test('reloadGeoJsonFromQrImagePicker loads QR image selection', () async {
+      final tempDir =
+          await Directory.systemTemp.createTemp('argus_qr_image_test_');
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+      final bundle = await encodeGeoJson(
+        const GeoJsonQrEncodeInput(
+          geoJson: _squareGeoJson,
+          scheme: GeoJsonQrScheme.gjz1,
+          generatePng: false,
+        ),
+      );
+      String? analyzedPath;
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _QrImageFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        qrImageAnalyzer: (path) async {
+          analyzedPath = path;
+          return bundle.qrTexts.single;
+        },
+      );
+
+      final loaded = await controller.reloadGeoJsonFromQrImagePicker();
+
+      expect(loaded, isTrue);
+      expect(analyzedPath, 'selected_qr.png');
+      expect(controller.geoJsonLoaded, isTrue);
+      expect(controller.snapshot.notes, 'GeoJSON loaded from QR code');
+      expect(controller.lastErrorMessage, isNull);
+    });
+
+    test('reloadGeoJsonFromQrImagePicker reports images without QR', () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _QrImageFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        qrImageAnalyzer: (_) async => null,
+      );
+
+      final loaded = await controller.reloadGeoJsonFromQrImagePicker();
+
+      expect(loaded, isFalse);
+      expect(controller.lastErrorMessage, 'QRコード画像からQRコードを読み取れませんでした。');
+      expect(controller.geoJsonLoaded, isFalse);
+    });
+
+    test('reloadGeoJsonFromQrImagePicker ignores picker cancellation',
+        () async {
+      final controller = AppController(
+        stateMachine: StateMachine(config: _testConfig()),
+        locationService: FakeLocationService(),
+        fileManager: _QrImageCancelFileManager(config: _testConfig()),
+        logger: FakeEventLogger(),
+        notifier: Notifier(
+          notificationsClient: FakeLocalNotificationsClient(),
+          alarmPlayer: FakeAlarmPlayer(),
+        ),
+        qrImageAnalyzer: (_) async => fail('analyzer should not be called'),
+      );
+
+      final loaded = await controller.reloadGeoJsonFromQrImagePicker();
+
+      expect(loaded, isFalse);
+      expect(controller.lastErrorMessage, isNull);
+    });
+
     test('cleanupTempGeoJsonFile deletes temporary file', () async {
       await _ensureBrotliCli();
 
@@ -997,6 +1075,29 @@ class FakeFileManager extends FileManager {
       mimeType: 'application/geo+json',
     );
   }
+
+  @override
+  Future<XFile?> pickQrImageFile() async {
+    return XFile.fromData(
+      Uint8List.fromList(const <int>[0]),
+      name: 'selected_qr.png',
+      mimeType: 'image/png',
+      path: 'selected_qr.png',
+    );
+  }
+}
+
+class _QrImageFileManager extends FakeFileManager {
+  _QrImageFileManager({required super.config});
+}
+
+class _QrImageCancelFileManager extends FakeFileManager {
+  _QrImageCancelFileManager({required super.config});
+
+  @override
+  Future<XFile?> pickQrImageFile() async {
+    return null;
+  }
 }
 
 class _SavingFileManager extends FakeFileManager {
@@ -1035,6 +1136,15 @@ class _ThrowingGeoJsonFileManager extends FakeFileManager {
   Future<XFile?> pickGeoJsonFile() async {
     throw error;
   }
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.temporaryPath);
+
+  final String temporaryPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => temporaryPath;
 }
 
 class FakeEventLogger extends EventLogger {

--- a/test/app_links_test.dart
+++ b/test/app_links_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:argus/app_links.dart';

--- a/test/io/file_manager_test.dart
+++ b/test/io/file_manager_test.dart
@@ -31,7 +31,7 @@ void main() {
     }
   });
 
-  test('pickGeoJsonFile passes expected file filter', () async {
+  test('pickGeoJsonFile opens picker without file filter', () async {
     List<XTypeGroup>? capturedGroups;
     final manager = FileManager(
       filePicker: ({acceptedTypeGroups}) async {
@@ -44,10 +44,7 @@ void main() {
 
     await manager.pickGeoJsonFile();
 
-    expect(capturedGroups, isNotNull);
-    expect(capturedGroups, hasLength(1));
-    expect(capturedGroups!.single.label, 'GeoJSON files');
-    expect(capturedGroups!.single.extensions, ['geojson', 'json', 'bin']);
+    expect(capturedGroups, isNull);
   });
 
   test('getConfigFile creates config file with default config when missing',

--- a/test/io/file_manager_test.dart
+++ b/test/io/file_manager_test.dart
@@ -47,6 +47,28 @@ void main() {
     expect(capturedGroups, isNull);
   });
 
+  test('pickQrImageFile opens picker with image filter', () async {
+    List<XTypeGroup>? capturedGroups;
+    final manager = FileManager(
+      filePicker: ({acceptedTypeGroups}) async {
+        capturedGroups = acceptedTypeGroups;
+        return null;
+      },
+      documentsDirectoryProvider: () async => tempDir,
+      defaultConfigLoader: () async => defaultConfig,
+    );
+
+    await manager.pickQrImageFile();
+
+    expect(capturedGroups, isNotNull);
+    expect(capturedGroups, hasLength(1));
+    expect(capturedGroups!.single.label, 'QR code image');
+    expect(capturedGroups!.single.extensions,
+        containsAll(<String>['png', 'jpg', 'jpeg', 'webp']));
+    expect(capturedGroups!.single.mimeTypes,
+        containsAll(<String>['image/png', 'image/jpeg', 'image/webp']));
+  });
+
   test('getConfigFile creates config file with default config when missing',
       () async {
     final manager = FileManager(

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -77,7 +77,7 @@ void main() {
 
     await tester.pumpWidget(ArgusApp(controller: controller));
 
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('ARGUS'), findsWidgets);
   });

--- a/test/qr/geojson_qr_codec_test.dart
+++ b/test/qr/geojson_qr_codec_test.dart
@@ -58,6 +58,48 @@ void main() {
     expect(restored, bundle.minimizedGeoJson);
   });
 
+  test('encode and decode gjz1 round trip with hash succeeds', () async {
+    final bundle = await encodeGeoJson(
+      GeoJsonQrEncodeInput(
+        geoJson: sampleGeoJson,
+        scheme: GeoJsonQrScheme.gjz1,
+      ),
+    );
+
+    expect(bundle.isSplit, isFalse);
+    expect(bundle.qrTexts, hasLength(1));
+    expect(bundle.qrTexts.first.startsWith('gjz1:'), isTrue);
+    final payloadSection =
+        bundle.qrTexts.first.substring(bundle.qrTexts.first.indexOf(':') + 1);
+    final payload = payloadSection.split('#').first;
+    expect(payload.contains('='), isFalse);
+    expect(payload, matches(RegExp(r'^[A-Za-z0-9_-]+$')));
+    expect(bundle.hashHex, isNotNull);
+    expect(bundle.pngImages.first, isNotEmpty);
+
+    final restored =
+        await decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: bundle.qrTexts));
+    expect(restored, bundle.minimizedGeoJson);
+  });
+
+  test('encode triggers gjz1p split when max length is low', () async {
+    final bundle = await encodeGeoJson(
+      GeoJsonQrEncodeInput(
+        geoJson: sampleGeoJson,
+        scheme: GeoJsonQrScheme.gjz1,
+        maxQrTextLength: 80,
+      ),
+    );
+
+    expect(bundle.isSplit, isTrue);
+    expect(bundle.qrTexts.length, greaterThan(1));
+    expect(bundle.qrTexts.every((text) => text.startsWith('gjz1p:')), isTrue);
+
+    final restored =
+        await decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: bundle.qrTexts));
+    expect(restored, bundle.minimizedGeoJson);
+  });
+
   test('decode fails when a gjb1p chunk is missing', () async {
     final bundle = await encodeGeoJson(
       GeoJsonQrEncodeInput(
@@ -95,6 +137,28 @@ void main() {
     );
   });
 
+  test('decode gjz1 fails on hash mismatch', () async {
+    final bundle = await encodeGeoJson(
+      GeoJsonQrEncodeInput(
+        geoJson: sampleGeoJson,
+        scheme: GeoJsonQrScheme.gjz1,
+      ),
+    );
+    final tampered = List<String>.from(bundle.qrTexts);
+
+    final text = tampered.single;
+    final separatorIndex = text.lastIndexOf('#');
+    final base = text.substring(0, separatorIndex + 1);
+    final hash = text.substring(separatorIndex + 1);
+    final firstChar = hash.startsWith('0') ? '1' : '0';
+    tampered[0] = '$base$firstChar${hash.substring(1)}';
+
+    await expectLater(
+      decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: tampered)),
+      throwsA(isA<HashMismatchException>()),
+    );
+  });
+
   test('decode rejects unsupported scheme', () async {
     await expectLater(
       decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['abc1:payload'])),
@@ -105,6 +169,10 @@ void main() {
   test('decode rejects invalid base64 payload', () async {
     await expectLater(
       decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjb1:@@@@'])),
+      throwsA(isA<DecodeFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjz1:@@@@'])),
       throwsA(isA<DecodeFailedException>()),
     );
   });
@@ -228,6 +296,24 @@ void main() {
     await expectLater(
       decodeGeoJson(
         const GeoJsonQrDecodeInput(qrTexts: ['gjb1:payload#xyz']),
+      ),
+      throwsA(isA<DecodeFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjz1p:abc'])),
+      throwsA(isA<UnsupportedSchemeException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(
+          qrTexts: ['gjz1p:0/2:a', 'gjz1p:2/2:b'],
+        ),
+      ),
+      throwsA(isA<ChunkMismatchException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(qrTexts: ['gjz1:payload#xyz']),
       ),
       throwsA(isA<DecodeFailedException>()),
     );

--- a/test/qr/geojson_qr_codec_test.dart
+++ b/test/qr/geojson_qr_codec_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:argus/qr/geojson_qr_codec.dart';
@@ -23,7 +24,7 @@ void main() {
     final bundle =
         await encodeGeoJson(GeoJsonQrEncodeInput(geoJson: sampleGeoJson));
 
-    expect(bundle.isSplit, isFalse);
+    expect(bundle.qrTexts, hasLength(1));
     expect(bundle.qrTexts, hasLength(1));
     expect(bundle.qrTexts.first.startsWith('gjb1:'), isTrue);
     final payloadSection =
@@ -41,23 +42,6 @@ void main() {
     expect(restored, bundle.minimizedGeoJson);
   });
 
-  test('encode triggers gjb1p split when max length is low', () async {
-    final bundle = await encodeGeoJson(
-      GeoJsonQrEncodeInput(
-        geoJson: sampleGeoJson,
-        maxQrTextLength: 80,
-      ),
-    );
-
-    expect(bundle.isSplit, isTrue);
-    expect(bundle.qrTexts.length, greaterThan(1));
-    expect(bundle.qrTexts.every((text) => text.startsWith('gjb1p:')), isTrue);
-
-    final restored =
-        await decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: bundle.qrTexts));
-    expect(restored, bundle.minimizedGeoJson);
-  });
-
   test('encode and decode gjz1 round trip with hash succeeds', () async {
     final bundle = await encodeGeoJson(
       GeoJsonQrEncodeInput(
@@ -66,7 +50,7 @@ void main() {
       ),
     );
 
-    expect(bundle.isSplit, isFalse);
+    expect(bundle.qrTexts, hasLength(1));
     expect(bundle.qrTexts, hasLength(1));
     expect(bundle.qrTexts.first.startsWith('gjz1:'), isTrue);
     final payloadSection =
@@ -82,37 +66,21 @@ void main() {
     expect(restored, bundle.minimizedGeoJson);
   });
 
-  test('encode triggers gjz1p split when max length is low', () async {
-    final bundle = await encodeGeoJson(
-      GeoJsonQrEncodeInput(
-        geoJson: sampleGeoJson,
-        scheme: GeoJsonQrScheme.gjz1,
-        maxQrTextLength: 80,
-      ),
-    );
-
-    expect(bundle.isSplit, isTrue);
-    expect(bundle.qrTexts.length, greaterThan(1));
-    expect(bundle.qrTexts.every((text) => text.startsWith('gjz1p:')), isTrue);
-
-    final restored =
-        await decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: bundle.qrTexts));
-    expect(restored, bundle.minimizedGeoJson);
+  test('gjz1 helper exposes wire name', () {
+    expect(GeoJsonQrScheme.gjz1.wireName, 'gjz1');
   });
 
-  test('decode fails when a gjb1p chunk is missing', () async {
-    final bundle = await encodeGeoJson(
-      GeoJsonQrEncodeInput(
-        geoJson: sampleGeoJson,
-        maxQrTextLength: 80,
-      ),
-    );
-
-    final tampered = List<String>.from(bundle.qrTexts)..removeAt(0);
-
+  test('encode rejects payloads that exceed max text length', () async {
     await expectLater(
-      decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: tampered)),
-      throwsA(isA<ChunkMismatchException>()),
+      encodeGeoJson(
+        GeoJsonQrEncodeInput(
+          geoJson: sampleGeoJson,
+          scheme: GeoJsonQrScheme.gjz1,
+          maxQrTextLength: 20,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<PayloadTooLargeException>()),
     );
   });
 
@@ -159,6 +127,28 @@ void main() {
     );
   });
 
+  test('decode gjz1 rejects empty payload and malformed hash suffix', () async {
+    await expectLater(
+      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjz1:'])),
+      throwsA(isA<DecodeFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJson(
+        const GeoJsonQrDecodeInput(qrTexts: ['gjz1:payload#xyz']),
+      ),
+      throwsA(isA<DecodeFailedException>()),
+    );
+  });
+
+  test('decode gjz1 rejects payloads that are not gzip data', () async {
+    final payload = base64UrlEncodeNoPad(utf8.encode('not gzip data'));
+
+    await expectLater(
+      decodeGeoJson(GeoJsonQrDecodeInput(qrTexts: ['gjz1:$payload'])),
+      throwsA(isA<DecompressFailedException>()),
+    );
+  });
+
   test('decode rejects unsupported scheme', () async {
     await expectLater(
       decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['abc1:payload'])),
@@ -179,7 +169,7 @@ void main() {
 
   test('bundle getters and exception toString expose metadata', () {
     final bundle = GeoJsonQrBundle(
-      qrTexts: const ['a', 'b'],
+      qrTexts: const ['a'],
       pngImages: const [],
       minimizedGeoJson: '{}',
       hashHex: null,
@@ -192,8 +182,7 @@ void main() {
     final payload = PayloadTooLargeException('too large');
     final qr = QrGenerationException('render failed');
 
-    expect(bundle.chunkCount, 2);
-    expect(bundle.isSplit, isTrue);
+    expect(bundle.qrTexts, const ['a']);
     expect(validation.toString(), contains('E_INVALID_GEOJSON'));
     expect(compress.toString(), contains('cli'));
     expect(decompress.code, 'E_DECOMPRESS_FAILED');
@@ -211,7 +200,7 @@ void main() {
     );
 
     expect(bundle.hashHex, isNull);
-    expect(bundle.chunkCount, 1);
+    expect(bundle.qrTexts, hasLength(1));
     expect(bundle.qrTexts.single, startsWith('gjb1:'));
     expect(bundle.qrTexts.single.contains('#'), isFalse);
   });
@@ -252,64 +241,12 @@ void main() {
     );
   });
 
-  test('buildGjB1pTexts rejects undersized limits', () {
-    expect(
-      () => buildGjB1pTexts('payload', maxLength: 12),
-      throwsA(isA<PayloadTooLargeException>()),
-    );
-    expect(
-      () => buildGjB1pTexts('x' * 1000, maxLength: 13),
-      throwsA(isA<PayloadTooLargeException>()),
-    );
-  });
-
-  test('decode rejects malformed gjb1p metadata and malformed hash suffix',
-      () async {
-    await expectLater(
-      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjb1p:abc'])),
-      throwsA(isA<UnsupportedSchemeException>()),
-    );
-    await expectLater(
-      decodeGeoJson(
-        const GeoJsonQrDecodeInput(
-          qrTexts: ['gjb1p:0/2:a', 'gjb1p:2/2:b'],
-        ),
-      ),
-      throwsA(isA<ChunkMismatchException>()),
-    );
-    await expectLater(
-      decodeGeoJson(
-        const GeoJsonQrDecodeInput(
-          qrTexts: ['gjb1p:1/2:a', 'gjb1p:2/3:b'],
-        ),
-      ),
-      throwsA(isA<ChunkMismatchException>()),
-    );
-    await expectLater(
-      decodeGeoJson(
-        const GeoJsonQrDecodeInput(
-          qrTexts: ['gjb1p:1/2:a', 'gjb1p:1/2:b'],
-        ),
-      ),
-      throwsA(isA<ChunkMismatchException>()),
-    );
+  test('decode rejects malformed hash suffix', () async {
     await expectLater(
       decodeGeoJson(
         const GeoJsonQrDecodeInput(qrTexts: ['gjb1:payload#xyz']),
       ),
       throwsA(isA<DecodeFailedException>()),
-    );
-    await expectLater(
-      decodeGeoJson(const GeoJsonQrDecodeInput(qrTexts: ['gjz1p:abc'])),
-      throwsA(isA<UnsupportedSchemeException>()),
-    );
-    await expectLater(
-      decodeGeoJson(
-        const GeoJsonQrDecodeInput(
-          qrTexts: ['gjz1p:0/2:a', 'gjz1p:2/2:b'],
-        ),
-      ),
-      throwsA(isA<ChunkMismatchException>()),
     );
     await expectLater(
       decodeGeoJson(

--- a/test/support/platform_mocks.dart
+++ b/test/support/platform_mocks.dart
@@ -1,10 +1,8 @@
-import 'dart:typed_data';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-const MethodChannel _assetsChannel = MethodChannel('flutter/assets');
 const MethodChannel _urlLauncherChannel =
     MethodChannel('plugins.flutter.io/url_launcher');
 

--- a/test/support/test_doubles.dart
+++ b/test/support/test_doubles.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:argus/app_controller.dart';
 import 'package:argus/geo/area_index.dart';
@@ -54,6 +55,17 @@ class FakeFileManager extends FileManager {
       utf8.encode(_squareGeoJson),
       name: 'test_square.geojson',
       mimeType: 'application/geo+json',
+      path: 'test_square.geojson',
+    );
+  }
+
+  @override
+  Future<XFile?> pickQrImageFile() async {
+    return XFile.fromData(
+      Uint8List.fromList(const <int>[0]),
+      name: 'qr.png',
+      mimeType: 'image/png',
+      path: 'qr.png',
     );
   }
 }
@@ -107,6 +119,7 @@ AppController buildTestController({
   bool? developerMode,
   MonitoringPermissionState? permissionState,
   PermissionCoordinator? permissionCoordinator,
+  QrImageAnalyzer? qrImageAnalyzer,
 }) {
   final config = createTestConfig();
   final stateMachine = StateMachine(config: config);
@@ -121,6 +134,7 @@ AppController buildTestController({
       alarmPlayer: FakeAlarmPlayer(),
     ),
     permissionCoordinator: permissionCoordinator,
+    qrImageAnalyzer: qrImageAnalyzer,
   );
 
   GeoModel? geoModel;

--- a/test/ui/background_location_disclosure_page_test.dart
+++ b/test/ui/background_location_disclosure_page_test.dart
@@ -117,7 +117,7 @@ class _DisclosureTestController extends AppController {
         ) {
     debugSeed(
       config: createTestConfig(),
-      permissionState: MonitoringPermissionState(
+      permissionState: const MonitoringPermissionState(
         notificationStatus: PermissionStatus.granted,
         locationWhenInUseStatus: PermissionStatus.granted,
         locationAlwaysStatus: PermissionStatus.denied,

--- a/test/ui/home_page_test.dart
+++ b/test/ui/home_page_test.dart
@@ -159,7 +159,7 @@ void main() {
   });
 
   testWidgets(
-      'bottom actions show Load GeoJSON and Read QR code (no Start button)',
+      'bottom actions show file loader and QR camera buttons (no Start button)',
       (tester) async {
     final controller = buildTestController(
       hasGeoJson: true,
@@ -172,9 +172,66 @@ void main() {
 
     await _pumpHome(tester, controller);
 
-    expect(find.text('Load GeoJSON'), findsOneWidget);
-    expect(find.text('Read QR code'), findsOneWidget);
+    expect(find.text('ファイルを\n読み込む'), findsOneWidget);
+    expect(find.text('QRコードを\n読み込む'), findsOneWidget);
+    expect(find.text('created by Kaito YAMADA'), findsOneWidget);
     expect(find.text('Start monitoring'), findsNothing);
+  });
+
+  testWidgets('file loader opens GeoJSON and QR image choices', (tester) async {
+    final controller = buildTestController(hasGeoJson: true);
+
+    await _pumpHome(tester, controller);
+
+    await tester.ensureVisible(find.text('ファイルを\n読み込む'));
+    await tester.tap(find.text('ファイルを\n読み込む'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GeoJSONファイルを読み込む'), findsOneWidget);
+    expect(find.text('QRコード画像を読み込む'), findsOneWidget);
+  });
+
+  testWidgets('file loader GeoJSON choice loads selected file', (tester) async {
+    final controller = buildTestController(hasGeoJson: false);
+
+    await _pumpHome(tester, controller);
+    expect(find.textContaining('ファイル名: -'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('ファイルを\n読み込む'));
+    await tester.tap(find.text('ファイルを\n読み込む'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('GeoJSONファイルを読み込む'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    expect(controller.geoJsonLoaded, isTrue);
+    expect(find.textContaining('ファイル名: test_square.geojson'), findsOneWidget);
+  });
+
+  testWidgets('file loader QR image choice decodes selected image',
+      (tester) async {
+    String? analyzedPath;
+    final controller = buildTestController(
+      hasGeoJson: false,
+      qrImageAnalyzer: (path) async {
+        analyzedPath = path;
+        return 'invalid:qr';
+      },
+    );
+
+    await _pumpHome(tester, controller);
+
+    await tester.ensureVisible(find.text('ファイルを\n読み込む'));
+    await tester.tap(find.text('ファイルを\n読み込む'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('QRコード画像を読み込む'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(analyzedPath, 'qr.png');
+    expect(controller.geoJsonLoaded, isFalse);
   });
 
   testWidgets('overflow menu opens QR generator page', (tester) async {

--- a/test/ui/home_page_test.dart
+++ b/test/ui/home_page_test.dart
@@ -177,6 +177,20 @@ void main() {
     expect(find.text('Start monitoring'), findsNothing);
   });
 
+  testWidgets('overflow menu opens QR generator page', (tester) async {
+    final controller = buildTestController(hasGeoJson: true);
+
+    await _pumpHome(tester, controller);
+
+    await tester.tap(find.byType(PopupMenuButton<int>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Generate QR code'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Generate QR code'), findsOneWidget);
+    expect(find.text('GeoJSONを選択'), findsOneWidget);
+  });
+
   testWidgets(
       'tapping start opens background disclosure when always permission is missing',
       (tester) async {

--- a/test/ui/qr_generator_page_test.dart
+++ b/test/ui/qr_generator_page_test.dart
@@ -79,7 +79,7 @@ void main() {
     expect(shared, isTrue);
   });
 
-  testWidgets('rejects split QR output and disables generated actions',
+  testWidgets('rejects encoder output without a single PNG image',
       (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -91,8 +91,8 @@ void main() {
             path: 'large.geojson',
           ),
           encoder: (input) async => GeoJsonQrBundle(
-            qrTexts: const ['gjz1p:1/2:a', 'gjz1p:2/2:b'],
-            pngImages: [qrPng, qrPng],
+            qrTexts: const ['gjz1:test'],
+            pngImages: const [],
             minimizedGeoJson: '{"type":"FeatureCollection","features":[]}',
             hashHex: null,
             info: const GeoJsonInfo(
@@ -111,6 +111,131 @@ void main() {
     expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
     expect(find.text('保存'), findsNothing);
     expect(find.text('共有'), findsNothing);
+  });
+
+  testWidgets('cancelled file selection clears generating state',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => null,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GeoJSONを選択'), findsOneWidget);
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
+    expect(find.text('保存'), findsNothing);
+    expect(find.text('共有'), findsNothing);
+    expect(find.byIcon(Icons.error_outline), findsNothing);
+  });
+
+  testWidgets('surfaces GeoJSON QR generation errors', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'course.geojson',
+            mimeType: 'application/geo+json',
+            path: 'course.geojson',
+          ),
+          encoder: (input) async => throw QrGenerationException('too large'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('QRコードの生成に失敗しました'), findsOneWidget);
+    expect(find.textContaining('too large'), findsOneWidget);
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
+  });
+
+  testWidgets('surfaces GeoJSON format errors', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'course.geojson',
+            mimeType: 'application/geo+json',
+            path: 'course.geojson',
+          ),
+          encoder: (input) async => throw const FormatException('bad json'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('GeoJSONの形式が正しくありません'), findsOneWidget);
+    expect(find.textContaining('bad json'), findsOneWidget);
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
+  });
+
+  testWidgets('surfaces unexpected generation errors', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'course.geojson',
+            mimeType: 'application/geo+json',
+            path: 'course.geojson',
+          ),
+          encoder: (input) async => throw Exception('boom'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('QRコードの生成中にエラーが発生しました'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('boom'), findsOneWidget);
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
+  });
+
+  testWidgets('renders preview without optional hash and feature count',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: '',
+            mimeType: 'application/geo+json',
+            path: r'C:\tmp\fallback.geojson',
+          ),
+          encoder: (input) async => GeoJsonQrBundle(
+            qrTexts: const ['payload-without-prefix'],
+            pngImages: [qrPng],
+            minimizedGeoJson: '{"type":"Point","coordinates":[0,0]}',
+            hashHex: null,
+            info: const GeoJsonInfo(type: 'Point'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsOneWidget);
+    expect(find.text('fallback.geojson'), findsOneWidget);
+    expect(find.text('Point'), findsOneWidget);
+    expect(find.text('-'), findsOneWidget);
+    expect(find.text('ハッシュ'), findsNothing);
+    expect(find.text('フィーチャ数'), findsNothing);
   });
 
   testWidgets('surfaces save and share failures with SnackBars',

--- a/test/ui/qr_generator_page_test.dart
+++ b/test/ui/qr_generator_page_test.dart
@@ -214,7 +214,7 @@ void main() {
             utf8.encode(_squareGeoJson),
             name: '',
             mimeType: 'application/geo+json',
-            path: r'C:\tmp\fallback.geojson',
+            path: 'fallback.geojson',
           ),
           encoder: (input) async => GeoJsonQrBundle(
             qrTexts: const ['payload-without-prefix'],

--- a/test/ui/qr_generator_page_test.dart
+++ b/test/ui/qr_generator_page_test.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:argus/qr/geojson_qr_codec.dart';
+import 'package:argus/ui/qr_generator_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Uint8List qrPng;
+
+  setUpAll(() {
+    qrPng = generateQrPng('gjz1:test', QrErrorCorrectionLevel.quartile);
+  });
+
+  testWidgets('generates single QR and enables save and share actions',
+      (tester) async {
+    var saved = false;
+    var shared = false;
+    GeoJsonQrScheme? requestedScheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'course.geojson',
+            mimeType: 'application/geo+json',
+            path: 'course.geojson',
+          ),
+          encoder: (input) async {
+            requestedScheme = input.scheme;
+            return GeoJsonQrBundle(
+              qrTexts: const ['gjz1:test'],
+              pngImages: [qrPng],
+              minimizedGeoJson: '{"type":"FeatureCollection","features":[]}',
+              hashHex: 'a' * 64,
+              info: const GeoJsonInfo(
+                type: 'FeatureCollection',
+                featureCount: 0,
+              ),
+            );
+          },
+          gallerySaver: (bytes, name) async {
+            saved = true;
+          },
+          shareHandler: (bytes, fileName, context) async {
+            shared = true;
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('GeoJSONを選択'), findsOneWidget);
+    expect(find.text('保存'), findsNothing);
+    expect(find.text('共有'), findsNothing);
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsOneWidget);
+    expect(requestedScheme, GeoJsonQrScheme.gjz1);
+    expect(find.text('保存'), findsOneWidget);
+    expect(find.text('共有'), findsOneWidget);
+    expect(find.text('course.geojson'), findsOneWidget);
+    expect(find.text('gjz1'), findsOneWidget);
+
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+    expect(saved, isTrue);
+    expect(find.text('写真に保存しました'), findsOneWidget);
+
+    await tester.tap(find.text('共有'));
+    await tester.pumpAndSettle();
+    expect(shared, isTrue);
+  });
+
+  testWidgets('rejects split QR output and disables generated actions',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'large.geojson',
+            mimeType: 'application/geo+json',
+            path: 'large.geojson',
+          ),
+          encoder: (input) async => GeoJsonQrBundle(
+            qrTexts: const ['gjz1p:1/2:a', 'gjz1p:2/2:b'],
+            pngImages: [qrPng, qrPng],
+            minimizedGeoJson: '{"type":"FeatureCollection","features":[]}',
+            hashHex: null,
+            info: const GeoJsonInfo(
+              type: 'FeatureCollection',
+              featureCount: 0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('1枚のQRに収まりません'), findsOneWidget);
+    expect(find.byKey(const ValueKey('generated_qr_image')), findsNothing);
+    expect(find.text('保存'), findsNothing);
+    expect(find.text('共有'), findsNothing);
+  });
+
+  testWidgets('surfaces save and share failures with SnackBars',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: QrGeneratorPage(
+          filePicker: () async => XFile.fromData(
+            utf8.encode(_squareGeoJson),
+            name: 'course.geojson',
+            mimeType: 'application/geo+json',
+            path: 'course.geojson',
+          ),
+          encoder: (input) async => GeoJsonQrBundle(
+            qrTexts: const ['gjz1:test'],
+            pngImages: [qrPng],
+            minimizedGeoJson: '{"type":"FeatureCollection","features":[]}',
+            hashHex: null,
+            info: const GeoJsonInfo(
+              type: 'FeatureCollection',
+              featureCount: 0,
+            ),
+          ),
+          gallerySaver: (bytes, name) async => throw Exception('save failed'),
+          shareHandler: (bytes, fileName, context) async =>
+              throw Exception('share failed'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('GeoJSONを選択'));
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -260));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('保存に失敗しました'), findsOneWidget);
+
+    ScaffoldMessenger.of(
+      tester.element(find.byType(QrGeneratorPage)),
+    ).clearSnackBars();
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -80));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('共有'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('共有に失敗しました'), findsOneWidget);
+  });
+}
+
+const String _squareGeoJson = '''
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Test Area"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]
+      }
+    }
+  ]
+}
+''';

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:mobile_scanner/src/enums/mobile_scanner_error_code.dart';
 import 'package:provider/provider.dart';
 
 import 'package:argus/app_controller.dart';

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -39,7 +39,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: ChangeNotifierProvider<AppController>.value(
-              value: controller,
+            value: controller,
             child: QrScannerPage(
               permissionCoordinator: _FakePermissionCoordinator(),
               scannerOverride: const ColoredBox(color: Colors.black),
@@ -79,7 +79,8 @@ void main() {
                       MaterialPageRoute(
                         builder: (_) => QrScannerPage(
                           permissionCoordinator: _FakePermissionCoordinator(),
-                          scannerOverride: const ColoredBox(color: Colors.black),
+                          scannerOverride:
+                              const ColoredBox(color: Colors.black),
                         ),
                       ),
                     );
@@ -278,7 +279,46 @@ void main() {
       expect(find.text('GeoJSON の読込に失敗しました。'), findsOneWidget);
     });
 
-    testWidgets('successful QR load pops scanner route', (WidgetTester tester) async {
+    testWidgets('valid gjz1 QR is accepted by scanner',
+        (WidgetTester tester) async {
+      final controller = _RecordingQrController()
+        ..loadedResult = false
+        ..reloadErrorMessage = 'GeoJSON の読込に失敗しました。';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppController>.value(
+            value: controller,
+            child: QrScannerPage(
+              permissionCoordinator: _FakePermissionCoordinator(),
+              scannerOverride: const SizedBox.shrink(),
+              scannerBuilder: (context, scannerController, onDetect) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => onDetect(
+                      const BarcodeCapture(
+                        barcodes: [Barcode(rawValue: 'gjz1:test')],
+                      ),
+                    ),
+                    child: const Text('Emit GJZ1'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Emit GJZ1'));
+      await tester.pumpAndSettle();
+
+      expect(controller.scannedTexts, ['gjz1:test']);
+      expect(find.text('GeoJSON の読込に失敗しました。'), findsOneWidget);
+    });
+
+    testWidgets('successful QR load pops scanner route',
+        (WidgetTester tester) async {
       final controller = _RecordingQrController()..loadedResult = true;
 
       await tester.pumpWidget(
@@ -290,17 +330,21 @@ void main() {
                 onPressed: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (_) => ChangeNotifierProvider<AppController>.value(
+                      builder: (_) =>
+                          ChangeNotifierProvider<AppController>.value(
                         value: controller,
                         child: QrScannerPage(
                           permissionCoordinator: _FakePermissionCoordinator(),
                           scannerOverride: const SizedBox.shrink(),
-                          scannerBuilder: (context, scannerController, onDetect) {
+                          scannerBuilder:
+                              (context, scannerController, onDetect) {
                             return Center(
                               child: ElevatedButton(
                                 onPressed: () => onDetect(
                                   const BarcodeCapture(
-                                    barcodes: [Barcode(rawValue: 'gjb1:success')],
+                                    barcodes: [
+                                      Barcode(rawValue: 'gjb1:success')
+                                    ],
                                   ),
                                 ),
                                 child: const Text('Emit Success'),
@@ -649,7 +693,8 @@ void main() {
       expect(find.textContaining('QR スキャナを開始できませんでした'), findsWidgets);
     });
 
-    testWidgets('retry in error state restarts scanner when camera already granted',
+    testWidgets(
+        'retry in error state restarts scanner when camera already granted',
         (WidgetTester tester) async {
       final controller = _buildController();
       var startCount = 0;
@@ -874,7 +919,8 @@ class _FakePermissionGateway implements PermissionGateway {
       PermissionStatus.granted;
 
   @override
-  Future<PermissionStatus> notificationStatus() async => PermissionStatus.granted;
+  Future<PermissionStatus> notificationStatus() async =>
+      PermissionStatus.granted;
 
   @override
   Future<PermissionStatus> requestCamera() async => PermissionStatus.granted;
@@ -888,7 +934,8 @@ class _FakePermissionGateway implements PermissionGateway {
       PermissionStatus.granted;
 
   @override
-  Future<PermissionStatus> requestNotification() async => PermissionStatus.granted;
+  Future<PermissionStatus> requestNotification() async =>
+      PermissionStatus.granted;
 }
 
 class _FakePermissionCoordinator extends PermissionCoordinator {

--- a/test/ui/settings_page_test.dart
+++ b/test/ui/settings_page_test.dart
@@ -32,24 +32,6 @@ Future<void> _pumpSettings(
   }
 }
 
-Future<void> _pumpUntilVisible(
-  WidgetTester tester,
-  Finder finder, {
-  int maxTicks = 10,
-}) async {
-  for (var i = 0; i < maxTicks; i++) {
-    await tester.pump();
-    if (finder.evaluate().isNotEmpty) {
-      return;
-    }
-    await tester.pump(const Duration(milliseconds: 50));
-    if (finder.evaluate().isNotEmpty) {
-      return;
-    }
-  }
-  fail('Widget not found after pumping.');
-}
-
 Future<void> _scrollUntilVisible(WidgetTester tester, Finder finder) async {
   await tester.scrollUntilVisible(
     finder,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -78,8 +78,8 @@ void main() {
     // Build our app and trigger a frame.
     await tester.pumpWidget(ArgusApp(controller: controller));
 
-    // Wait for the widget to build
-    await tester.pumpAndSettle();
+    // Wait for the first frame to build.
+    await tester.pump();
 
     // Verify that the app title 'ARGUS' is displayed
     expect(find.text('ARGUS'), findsWidgets);


### PR DESCRIPTION
## Summary
- アプリ内に GeoJSON からQRコードを生成する画面を追加しました。
- Android端末上でも生成できるよう、生成側はDart標準のgzipを使う `gjz1` 形式に変更しました。
- 読み込み側は既存の `gjb1` と新しい `gjz1` の両方を受け付けるようにし、既存QRとの互換性を維持しました。
- 分割QRは今回の対象外としてロジックとテストから外し、1枚に収まらない場合は生成エラーとして扱います。

## Changes
- 右上メニューから `Generate QR code` を開けるようにし、GeoJSON選択、QRプレビュー、保存、共有を実装しました。
- Androidで `.geojson` が選択しやすいよう、ファイルピッカーの拡張子フィルタを外しました。
- 起動画面を削除し、アプリ起動時は直接ホーム画面を表示します。
- 写真保存/共有に必要な依存とAndroid/iOS設定を追加しました。
- CIで `flutter analyze` を実行するようにしました。

## Testing
- `flutter analyze`
- `flutter test test/qr/geojson_qr_codec_test.dart`
- `flutter test test/ui/qr_generator_page_test.dart`
- `flutter test test/ui/qr_scanner_page_test.dart`
- `flutter test test/io/file_manager_test.dart`
- `flutter test --coverage`
- `flutter test`
- Android実機へ debug APK をビルド・インストールして起動確認

## Notes
- QR生成は単一QRのみ対応です。容量を超えるGeoJSONでは「1枚のQRに収まりません」と表示します。
- `gjb1` 生成は互換目的で残していますが、アプリ内生成では `gjz1` を使用します。
