### PR TITLE
長押しで停止確認ダイアログを追加し誤操作防止を実装

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -114,6 +114,10 @@ class HomePage extends StatelessWidget {
                                   isWaitStart: snapshot.status ==
                                       LocationStateStatus.waitStart,
                                   geoJsonReady: controller.geoJsonLoaded,
+                                  showStopAction: snapshot.status !=
+                                          LocationStateStatus.waitGeoJson &&
+                                      snapshot.status !=
+                                          LocationStateStatus.waitStart,
                                   onLoadFile: () {
                                     _showLoadFileSheet(context, controller);
                                   },
@@ -124,6 +128,7 @@ class HomePage extends StatelessWidget {
                                       ),
                                     );
                                   },
+                                  onStopMonitoring: controller.stopMonitoring,
                                 ),
                                 // developerモードでは常に方角と距離を表示
                                 if (showNav) ...[
@@ -298,6 +303,10 @@ class HomePage extends StatelessWidget {
                                     isWaitStart: snapshot.status ==
                                         LocationStateStatus.waitStart,
                                     geoJsonReady: controller.geoJsonLoaded,
+                                    showStopAction: snapshot.status !=
+                                            LocationStateStatus.waitGeoJson &&
+                                        snapshot.status !=
+                                            LocationStateStatus.waitStart,
                                     onLoadFile: () {
                                       _showLoadFileSheet(context, controller);
                                     },
@@ -308,6 +317,8 @@ class HomePage extends StatelessWidget {
                                                 const QrScannerPage()),
                                       );
                                     },
+                                    onStopMonitoring:
+                                        controller.stopMonitoring,
                                   ),
                                   // outerの時に方角と距離を表示
                                   if (showNav &&
@@ -483,14 +494,18 @@ class _BottomActions extends StatelessWidget {
   const _BottomActions({
     required this.isWaitStart,
     required this.geoJsonReady,
+    required this.showStopAction,
     required this.onLoadFile,
     required this.onOpenQr,
+    required this.onStopMonitoring,
   });
 
   final bool isWaitStart;
   final bool geoJsonReady;
+  final bool showStopAction;
   final VoidCallback onLoadFile;
   final VoidCallback onOpenQr;
+  final Future<void> Function() onStopMonitoring;
 
   @override
   Widget build(BuildContext context) {
@@ -523,7 +538,102 @@ class _BottomActions extends StatelessWidget {
             ),
           ],
         ),
+        if (showStopAction) ...[
+          const SizedBox(height: 12),
+          _StopMonitoringAction(onConfirmStop: onStopMonitoring),
+        ],
       ],
+    );
+  }
+}
+
+class _StopMonitoringAction extends StatefulWidget {
+  const _StopMonitoringAction({required this.onConfirmStop});
+
+  final Future<void> Function() onConfirmStop;
+
+  @override
+  State<_StopMonitoringAction> createState() => _StopMonitoringActionState();
+}
+
+class _StopMonitoringActionState extends State<_StopMonitoringAction> {
+  bool isStopConfirmOpen = false;
+  bool _isStopping = false;
+
+  Future<void> _openStopConfirmDialog() async {
+    if (isStopConfirmOpen || _isStopping) {
+      return;
+    }
+
+    setState(() {
+      isStopConfirmOpen = true;
+    });
+
+    final shouldStop = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('停止の確認'),
+        content: const Text('進行中の処理を停止します。よろしいですか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('終了する'),
+          ),
+        ],
+      ),
+    );
+
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      isStopConfirmOpen = false;
+    });
+
+    if (shouldStop != true) {
+      return;
+    }
+
+    setState(() {
+      _isStopping = true;
+    });
+    await widget.onConfirmStop();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isStopping = false;
+    });
+  }
+
+  void _showLongPressHint() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('停止するには長押ししてください。')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton.tonalIcon(
+        key: const Key('stopMonitoringLongPressButton'),
+        onPressed: _isStopping ? null : _showLongPressHint,
+        onLongPress: _isStopping ? null : _openStopConfirmDialog,
+        icon: _isStopping
+            ? const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.stop_circle_outlined),
+        label: Text(_isStopping ? '停止中...' : '長押しで停止'),
+      ),
     );
   }
 }

--- a/test/ui/home_page_test.dart
+++ b/test/ui/home_page_test.dart
@@ -248,6 +248,61 @@ void main() {
     expect(find.text('GeoJSONを選択'), findsOneWidget);
   });
 
+  testWidgets('長押し成立で停止確認ダイアログを表示し、キャンセルで継続する',
+      (tester) async {
+    final controller = buildTestController(
+      hasGeoJson: true,
+      snapshot: StateSnapshot(
+        status: LocationStateStatus.outer,
+        timestamp: DateTime.utc(2024, 1, 1),
+        geoJsonLoaded: true,
+      ),
+    );
+    final locationService = controller.locationService as FakeLocationService;
+
+    await _pumpHome(tester, controller);
+
+    final stopButton = find.byKey(const Key('stopMonitoringLongPressButton'));
+    expect(stopButton, findsOneWidget);
+
+    await tester.longPress(stopButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('停止の確認'), findsOneWidget);
+    expect(find.text('進行中の処理を停止します。よろしいですか？'), findsOneWidget);
+
+    await tester.tap(find.text('ファイルを\n読み込む'));
+    await tester.pumpAndSettle();
+    expect(find.text('GeoJSONファイルを読み込む'), findsNothing);
+
+    await tester.tap(find.text('キャンセル'));
+    await tester.pumpAndSettle();
+
+    expect(locationService.hasStopped, isFalse);
+  });
+
+  testWidgets('長押し成立後に終了するを選ぶと停止処理を実行する', (tester) async {
+    final controller = buildTestController(
+      hasGeoJson: true,
+      snapshot: StateSnapshot(
+        status: LocationStateStatus.outer,
+        timestamp: DateTime.utc(2024, 1, 1),
+        geoJsonLoaded: true,
+      ),
+    );
+    final locationService = controller.locationService as FakeLocationService;
+
+    await _pumpHome(tester, controller);
+
+    await tester.longPress(find.byKey(const Key('stopMonitoringLongPressButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('終了する'));
+    await tester.pumpAndSettle();
+
+    expect(locationService.hasStopped, isTrue);
+    expect(find.text('停止の確認'), findsNothing);
+  });
+
   testWidgets(
       'tapping start opens background disclosure when always permission is missing',
       (tester) async {


### PR DESCRIPTION
### Motivation
- 外側状態での誤操作による即時停止を防ぎ、長押し→確認ダイアログ→確定で停止する安全な操作フローを導入するため。 

### Description
- 画面下部アクションに長押しで停止するUIを追加するため、`_StopMonitoringAction`（`lib/ui/home_page.dart`）を実装し長押しで確認ダイアログを出すようにした。 
- ダイアログは`barrierDismissible: false`で背景操作を無効化し、文言を「進行中の処理を停止します。よろしいですか？」と危険操作として明確化した。 
- 多重表示・連打防止のため`isStopConfirmOpen`フラグと`_isStopping`フラグを導入し、ボタンは短押しでヒントを表示、長押しでダイアログを開く挙動にした。 
- `BottomActions`に表示条件（`showStopAction`）を追加して`waitGeoJson`/`waitStart`以外の状態でのみ停止アクションを表示し、停止処理は`controller.stopMonitoring`に接続した。 
- 画面テストを追加して「長押し成立→ダイアログ→キャンセルで継続」「長押し成立→終了するで停止」を検証するケースを追加した（`test/ui/home_page_test.dart`）。 
- 変更ファイル: `lib/ui/home_page.dart`, `test/ui/home_page_test.dart` （PR注記: created by Codex）

### Testing
- 追加したウィジェットテストは`test/ui/home_page_test.dart`に実装したが、ローカル実行で`flutter test test/ui/home_page_test.dart`を実行したところ実行環境に`flutter`が存在せずテストは実行できなかった（失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f063a1f7a883278e2679738bfc14df)