### PR TITLE
Fix race finish button placement and stop state

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -169,6 +169,17 @@ class AppController extends ChangeNotifier {
     await _subscription?.cancel();
     _subscription = null;
     await locationService.stop();
+    stateMachine.updateGeometry(_geoModel, _areaIndex);
+    _snapshot = StateSnapshot(
+      status: geoJsonLoaded
+          ? LocationStateStatus.waitStart
+          : LocationStateStatus.waitGeoJson,
+      timestamp: DateTime.now(),
+      geoJsonLoaded: geoJsonLoaded,
+      notes: geoJsonLoaded
+          ? 'Monitoring stopped. Ready to restart.'
+          : 'Monitoring stopped. Load GeoJSON to start monitoring.',
+    );
     _logInfo('APP', 'Monitoring stopped.');
     notifyListeners();
   }

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -100,6 +102,7 @@ class _HomeScrollableContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDeveloperMode = controller.developerMode;
+    final isMonitoring = _isMonitoringStatus(snapshot.status);
     return LayoutBuilder(
       builder: (context, constraints) {
         return SingleChildScrollView(
@@ -125,7 +128,14 @@ class _HomeScrollableContent extends StatelessWidget {
                           fileName: controller.geoJsonFileName,
                           loaded: controller.geoJsonLoaded,
                         ),
-                        const SizedBox(height: 12),
+                        if (isMonitoring) ...[
+                          const SizedBox(height: 24),
+                          _HoldToFinishRaceButton(
+                            duration: const Duration(seconds: 5),
+                            onCompleted: controller.stopMonitoring,
+                          ),
+                        ],
+                        const SizedBox(height: 20),
                         _LargeStatusDisplay(
                           status: snapshot.status,
                           onTap: snapshot.status ==
@@ -141,9 +151,7 @@ class _HomeScrollableContent extends StatelessWidget {
                         ),
                         const SizedBox(height: 12),
                         _BottomActions(
-                          isWaitStart:
-                              snapshot.status == LocationStateStatus.waitStart,
-                          geoJsonReady: controller.geoJsonLoaded,
+                          status: snapshot.status,
                           onLoadFile: () {
                             _showLoadFileSheet(context, controller);
                           },
@@ -421,23 +429,28 @@ class _FileNameInfo extends StatelessWidget {
 
 class _BottomActions extends StatelessWidget {
   const _BottomActions({
-    required this.isWaitStart,
-    required this.geoJsonReady,
+    required this.status,
     required this.onLoadFile,
     required this.onOpenQr,
   });
 
-  final bool isWaitStart;
-  final bool geoJsonReady;
+  final LocationStateStatus status;
   final VoidCallback onLoadFile;
   final VoidCallback onOpenQr;
 
+  bool get _isWaiting =>
+      status == LocationStateStatus.waitStart ||
+      status == LocationStateStatus.waitGeoJson;
+
   @override
   Widget build(BuildContext context) {
+    if (!_isWaiting) {
+      return const SizedBox.shrink();
+    }
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // 中央円タップで開始に統一（ボタンは出さない）
         Row(
           children: [
             Expanded(
@@ -464,6 +477,153 @@ class _BottomActions extends StatelessWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+bool _isMonitoringStatus(LocationStateStatus status) {
+  return status == LocationStateStatus.inner ||
+      status == LocationStateStatus.near ||
+      status == LocationStateStatus.outerPending ||
+      status == LocationStateStatus.outer ||
+      status == LocationStateStatus.gpsBad;
+}
+
+class _HoldToFinishRaceButton extends StatefulWidget {
+  const _HoldToFinishRaceButton({
+    required this.duration,
+    required this.onCompleted,
+  });
+
+  final Duration duration;
+  final Future<void> Function() onCompleted;
+
+  @override
+  State<_HoldToFinishRaceButton> createState() =>
+      _HoldToFinishRaceButtonState();
+}
+
+class _HoldToFinishRaceButtonState extends State<_HoldToFinishRaceButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  Timer? _finishTimer;
+  bool _completed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _HoldToFinishRaceButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+  }
+
+  @override
+  void dispose() {
+    _finishTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _startHold() {
+    if (_completed) {
+      return;
+    }
+    _finishTimer?.cancel();
+    _finishTimer = Timer(widget.duration, () {
+      if (_completed) {
+        return;
+      }
+      _completed = true;
+      unawaited(widget.onCompleted());
+    });
+    _controller.forward(from: 0);
+  }
+
+  void _cancelHold() {
+    if (_completed) {
+      return;
+    }
+    _finishTimer?.cancel();
+    _finishTimer = null;
+    _controller.reverse();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final baseColor = colorScheme.surfaceContainerHighest;
+    final fillColor = theme.colorScheme.error;
+    final textColor = colorScheme.onSurface;
+    final radius = BorderRadius.circular(8);
+
+    return Semantics(
+      key: const Key('finish-race-button'),
+      button: true,
+      label: '長押しでレース終了',
+      child: Material(
+        color: baseColor,
+        shape: RoundedRectangleBorder(
+          borderRadius: radius,
+          side: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: (_) => _startHold(),
+          onPointerUp: (_) => _cancelHold(),
+          onPointerCancel: (_) => _cancelHold(),
+          child: InkWell(
+            splashColor: fillColor.withValues(alpha: 0.12),
+            highlightColor: fillColor.withValues(alpha: 0.08),
+            child: AnimatedBuilder(
+              animation: _controller,
+              builder: (context, child) {
+                return Stack(
+                  children: [
+                    FractionallySizedBox(
+                      key: const Key('finish-race-progress-fill'),
+                      widthFactor: _controller.value,
+                      alignment: Alignment.centerLeft,
+                      child: Container(
+                        height: 52,
+                        color: fillColor.withValues(alpha: 0.86),
+                      ),
+                    ),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 52,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.stop_circle_outlined, color: textColor),
+                          const SizedBox(width: 8),
+                          Text(
+                            '長押しでレース終了',
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: textColor,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: "none"
-version: 0.3.1
+version: 0.3.3
 environment:
   sdk: ">=3.2.0 <4.0.0"
 

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -541,6 +541,34 @@ void main() {
       expect(locationService.stopped, isTrue);
     });
 
+    test('stopMonitoring returns loaded race to waitStart and clears fix data',
+        () async {
+      final controller = _buildController();
+      controller.debugSeed(
+        config: _testConfig(),
+        geoJson: _squareModel(),
+        snapshot: StateSnapshot(
+          status: LocationStateStatus.outer,
+          timestamp: DateTime.utc(2024, 1, 1),
+          geoJsonLoaded: true,
+          distanceToBoundaryM: 12,
+          horizontalAccuracyM: 4,
+          bearingToBoundaryDeg: 90,
+          nearestBoundaryPoint: const LatLng(1, 1),
+        ),
+      );
+
+      await controller.stopMonitoring();
+
+      expect(controller.snapshot.status, LocationStateStatus.waitStart);
+      expect(controller.stateMachine.current, LocationStateStatus.waitStart);
+      expect(controller.snapshot.geoJsonLoaded, isTrue);
+      expect(controller.snapshot.distanceToBoundaryM, isNull);
+      expect(controller.snapshot.horizontalAccuracyM, isNull);
+      expect(controller.snapshot.bearingToBoundaryDeg, isNull);
+      expect(controller.snapshot.nearestBoundaryPoint, isNull);
+    });
+
     test('stopMonitoring suppresses an in-flight outer location fix', () async {
       final config = _testConfig();
       final stateMachine = StateMachine(config: config);

--- a/test/ui/home_page_test.dart
+++ b/test/ui/home_page_test.dart
@@ -190,6 +190,88 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Start monitoring'), findsNothing);
+    expect(find.text('長押しでレース終了'), findsNothing);
+  });
+
+  testWidgets('bottom actions show file loaders while waiting for GeoJSON',
+      (tester) async {
+    final controller = buildTestController(
+      hasGeoJson: false,
+      snapshot: StateSnapshot(
+        status: LocationStateStatus.waitGeoJson,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+      ),
+    );
+
+    await _pumpHome(tester, controller);
+
+    expect(find.text('ファイルを\n読み込む'), findsOneWidget);
+    expect(find.text('QRコードを\n読み込む'), findsOneWidget);
+    expect(find.text('長押しでレース終了'), findsNothing);
+  });
+
+  testWidgets('bottom actions show only finish button while monitoring',
+      (tester) async {
+    final controller = buildTestController(
+      hasGeoJson: true,
+      snapshot: StateSnapshot(
+        status: LocationStateStatus.inner,
+        timestamp: DateTime.utc(2024, 1, 1),
+        geoJsonLoaded: true,
+      ),
+    );
+
+    await _pumpHome(tester, controller);
+
+    expect(find.text('ファイルを\n読み込む'), findsNothing);
+    expect(find.text('QRコードを\n読み込む'), findsNothing);
+    expect(find.text('長押しでレース終了'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byKey(const Key('finish-race-button'))).dy,
+      lessThan(tester.getTopLeft(find.text('内側')).dy),
+    );
+  });
+
+  testWidgets('finish button requires a full 5 second hold', (tester) async {
+    final controller = buildTestController(
+      hasGeoJson: true,
+      snapshot: StateSnapshot(
+        status: LocationStateStatus.inner,
+        timestamp: DateTime.utc(2024, 1, 1),
+        geoJsonLoaded: true,
+      ),
+    );
+    final locationService = controller.locationService as FakeLocationService;
+
+    await _pumpHome(tester, controller);
+    await tester.ensureVisible(find.text('長押しでレース終了'));
+    final finishButton = find.byKey(const Key('finish-race-button'));
+
+    final shortPress = await tester.startGesture(
+      tester.getCenter(finishButton),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    expect(find.byKey(const Key('finish-race-progress-fill')), findsOneWidget);
+    await shortPress.up();
+    await tester.pumpAndSettle();
+
+    expect(locationService.hasStopped, isFalse);
+    expect(find.text('長押しでレース終了'), findsOneWidget);
+
+    final fullHold = await tester.startGesture(
+      tester.getCenter(finishButton),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pump();
+    await fullHold.up();
+    await tester.pumpAndSettle();
+
+    expect(locationService.hasStopped, isTrue);
+    expect(find.text('スタート待機'), findsOneWidget);
+    expect(find.text('ファイルを\n読み込む'), findsOneWidget);
+    expect(find.text('QRコードを\n読み込む'), findsOneWidget);
   });
 
   testWidgets('contact link shows snackbar when mail app cannot open',


### PR DESCRIPTION
## Summary
- Move the monitoring stop control directly below the file name row to match the provided UI layout.
- Keep load buttons visible only in `waitStart` and `waitGeoJson`, while monitoring shows just the finish control and status circle.
- Preserve the 5-second hold-to-finish interaction with a left-to-right progress fill styled to align with the app's existing Material 3 surface treatment.

## Testing
- Added/updated unit tests for `AppController.stopMonitoring()` to verify state reset and cleanup behavior.
- Added/updated widget tests for waiting vs monitoring layouts and the 5-second hold completion flow.
- `flutter test test/app_controller_test.dart test/ui/home_page_test.dart` passed.