### PR TITLE
QRスキャンを同梱化し、監視中の終了操作とREADMEバッジを整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ARGUS
-![App icon](./icon.png)
 
-[![CI](https://github.com/nanigasi-san/Argus/workflows/CI/badge.svg)](https://github.com/YOUR_USERNAME/Argus/actions)
+[![CI](https://github.com/nanigasi-san/Argus/actions/workflows/ci.yml/badge.svg)](https://github.com/nanigasi-san/Argus/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nanigasi-san/Argus/branch/main/graph/badge.svg)](https://codecov.io/gh/nanigasi-san/Argus)
+
+![App icon](./icon.png)
 
 ## リリース運用
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,8 +79,5 @@ dependencies {
         implementation("androidx.camera:camera-lifecycle:1.5.3") {
             because("Align CameraX with the 16 KB page-size compatible release line.")
         }
-        implementation("com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1") {
-            because("Use the Play Services barcode scanner package required by the unbundled QR scanner setup.")
-        }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,9 +14,6 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true">
-        <meta-data
-            android:name="com.google.mlkit.vision.DEPENDENCIES"
-            android:value="barcode" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-dev.steenbakker.mobile_scanner.useUnbundled=true

--- a/lib/platform/location_service.dart
+++ b/lib/platform/location_service.dart
@@ -96,9 +96,9 @@ class GeolocatorLocationService implements LocationService {
         intervalDuration: interval,
         forceLocationManager: false,
         foregroundNotificationConfig: const ForegroundNotificationConfig(
-          notificationTitle: 'Argusが位置情報を監視中です',
+          notificationTitle: 'ARGUSが位置情報を監視中です',
           notificationText: '画面を消しても位置情報の追跡は継続されます。',
-          notificationChannelName: 'Argusバックグラウンド監視',
+          notificationChannelName: 'ARGUSバックグラウンド監視',
           enableWakeLock: true,
           setOngoing: true,
         ),

--- a/lib/platform/notifier.dart
+++ b/lib/platform/notifier.dart
@@ -32,7 +32,7 @@ class Notifier {
   );
 
   static const _channelId = 'argus_alerts';
-  static const _channelName = 'Argus警告';
+  static const _channelName = 'ARGUS警告';
   static const _channelDescription = 'ジオフェンスの安全エリアから離れたときに通知します。';
   static const int _outerNotificationId = 1001;
 
@@ -87,7 +87,7 @@ class Notifier {
       enableVibration: true,
       category: AndroidNotificationCategory.alarm,
       audioAttributesUsage: AudioAttributesUsage.alarm,
-      ticker: 'Argus警告',
+      ticker: 'ARGUS警告',
     );
     const iosDetails = DarwinNotificationDetails(
       presentAlert: true,
@@ -101,7 +101,7 @@ class Notifier {
     );
     await _notifications.show(
       _outerNotificationId,
-      'Argus警告',
+      'ARGUS警告',
       '競技エリアから離れています。',
       notificationDetails,
     );

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -128,13 +128,6 @@ class _HomeScrollableContent extends StatelessWidget {
                           fileName: controller.geoJsonFileName,
                           loaded: controller.geoJsonLoaded,
                         ),
-                        if (isMonitoring) ...[
-                          const SizedBox(height: 24),
-                          _HoldToFinishRaceButton(
-                            duration: const Duration(seconds: 5),
-                            onCompleted: controller.stopMonitoring,
-                          ),
-                        ],
                         const SizedBox(height: 20),
                         _LargeStatusDisplay(
                           status: snapshot.status,
@@ -150,19 +143,25 @@ class _HomeScrollableContent extends StatelessWidget {
                               : null,
                         ),
                         const SizedBox(height: 12),
-                        _BottomActions(
-                          status: snapshot.status,
-                          onLoadFile: () {
-                            _showLoadFileSheet(context, controller);
-                          },
-                          onOpenQr: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (_) => const QrScannerPage(),
-                              ),
-                            );
-                          },
-                        ),
+                        if (isMonitoring)
+                          _HoldToFinishRaceButton(
+                            duration: const Duration(seconds: 5),
+                            onCompleted: controller.stopMonitoring,
+                          )
+                        else
+                          _BottomActions(
+                            status: snapshot.status,
+                            onLoadFile: () {
+                              _showLoadFileSheet(context, controller);
+                            },
+                            onOpenQr: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const QrScannerPage(),
+                                ),
+                              );
+                            },
+                          ),
                         if (showNavigationDetails) ...[
                           const SizedBox(height: 24),
                           Text(

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -562,7 +562,7 @@ class _HoldToFinishRaceButtonState extends State<_HoldToFinishRaceButton>
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final baseColor = colorScheme.surfaceContainerHighest;
-    final fillColor = theme.colorScheme.error;
+    final fillColor = Colors.green;
     final textColor = colorScheme.onSurface;
     final radius = BorderRadius.circular(8);
 

--- a/lib/ui/qr_scanner_page.dart
+++ b/lib/ui/qr_scanner_page.dart
@@ -279,7 +279,7 @@ class _QrScannerPageState extends State<QrScannerPage>
         message.contains('barcode') ||
         message.contains('download') ||
         message.contains('google play')) {
-      return 'QR スキャナの準備中です。ネットワークに接続した状態で、しばらくしてから再試行してください。';
+      return 'QR スキャナを初期化できませんでした。アプリを再起動して再試行してください。';
     }
     return 'QR スキャナを開始できませんでした。再試行してください。';
   }

--- a/test/ui/home_page_test.dart
+++ b/test/ui/home_page_test.dart
@@ -228,7 +228,7 @@ void main() {
     expect(find.text('長押しでレース終了'), findsOneWidget);
     expect(
       tester.getTopLeft(find.byKey(const Key('finish-race-button'))).dy,
-      lessThan(tester.getTopLeft(find.text('内側')).dy),
+      greaterThan(tester.getTopLeft(find.text('内側')).dy),
     );
   });
 

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -574,7 +574,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+      expect(find.textContaining('アプリを再起動して再試行'), findsOneWidget);
     });
 
     testWidgets('scanner barcode start error shows retry guidance',
@@ -604,7 +604,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+      expect(find.textContaining('アプリを再起動して再試行'), findsOneWidget);
     });
 
     testWidgets('scanner download start error shows retry guidance',
@@ -634,7 +634,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+      expect(find.textContaining('アプリを再起動して再試行'), findsOneWidget);
     });
 
     testWidgets('scanner google play start error shows retry guidance',
@@ -664,7 +664,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('ネットワークに接続した状態'), findsOneWidget);
+      expect(find.textContaining('アプリを再起動して再試行'), findsOneWidget);
     });
 
     testWidgets('scanner generic start error shows generic failure message',


### PR DESCRIPTION
## Summary
- Android の QR スキャンを bundled ML Kit 構成に戻し、初回のネットワーク依存をなくしました。
- QR スキャナの初期化失敗メッセージを、ネット接続前提ではない案内に更新しました。
- 監視中のレース終了ボタンを、ファイル読み込みボタン群の位置に表示するように変更しました。
- README の先頭に CI と Codecov のバッジを追加し、アイコンとの並びを整理しました。
- 通知文言の `ARGUS` 表記を統一しました。

## Testing
- `flutter test test/ui/qr_scanner_page_test.dart`
- `flutter test test/ui/home_page_test.dart test/ui/qr_scanner_page_test.dart`
- `flutter test`
- `flutter build apk --release`
- `dart analyze lib/ui/qr_scanner_page.dart test/ui/qr_scanner_page_test.dart`