### PR TITLE
fix: プライバシーポリシーURLを統一しバージョンを0.4.0へ更新

### DIFF
--- a/docs/play_console_background_location_declaration.md
+++ b/docs/play_console_background_location_declaration.md
@@ -1,12 +1,12 @@
 # Google Play Background Location Declaration
 
-Last updated: 2026-04-13
+Last updated: 2026-05-31
 
 ## Privacy Policy URL
 
 Use this public URL in Play Console and in the app:
 
-- https://github.com/nanigasi-san/Argus/blob/main/privacy.md
+- https://argus-lp.vercel.app/privacy.html
 
 ## Core functionality description
 

--- a/lib/app_links.dart
+++ b/lib/app_links.dart
@@ -1,7 +1,7 @@
 import 'package:url_launcher/url_launcher.dart';
 
 const String privacyPolicyUrl =
-    'https://github.com/nanigasi-san/Argus/blob/main/privacy.md';
+    'https://argus-lp.vercel.app/privacy.html';
 const String contactEmail = 'yamada.orien@gmail.com';
 
 Future<bool> openPrivacyPolicy() {

--- a/privacy.md
+++ b/privacy.md
@@ -1,6 +1,6 @@
 # ARGUS Privacy Policy
 
-Last updated: 2026-04-04
+Last updated: 2026-05-31
 
 ARGUS is a geofencing support app. This policy explains what data the app uses and how that data is handled.
 
@@ -41,10 +41,12 @@ Data used by ARGUS remains on the device unless the user removes the app or dele
 
 ## 6. Contact
 
-Questions about this policy can be sent through the repository issue tracker:
+Questions about this policy can be sent to:
 
-- [ARGUS Issues](https://github.com/nanigasi-san/Argus/issues)
+- [yamada.orien@gmail.com](mailto:yamada.orien@gmail.com)
 
 ## 7. Changes
 
-This policy may be updated when the app or legal requirements change. The latest version will be published in this repository.
+This policy may be updated when the app or legal requirements change. The latest version will be published at:
+
+- [ARGUS Privacy Policy](https://argus-lp.vercel.app/privacy.html)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: "none"
-version: 0.3.3
+version: 0.4.0+11
 environment:
   sdk: ">=3.2.0 <4.0.0"
 

--- a/test/app_links_test.dart
+++ b/test/app_links_test.dart
@@ -5,6 +5,15 @@ import 'package:argus/app_links.dart';
 import 'support/platform_mocks.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('privacy policy uses the public non-editable URL', () {
+    expect(
+      privacyPolicyUrl,
+      'https://argus-lp.vercel.app/privacy.html',
+    );
+  });
+
   tearDown(() async {
     await clearUrlLauncherMock();
   });


### PR DESCRIPTION
## Summary
- LP で復旧済みの公開プライバシーポリシー URL にアプリ内リンクと審査資料を統一
- Android リリース向けアプリバージョンを `0.4.0+11` に更新
- 公開 URL を固定値で検証する回帰テストを追加

## Verification
- `flutter test`
- `flutter analyze`
- `https://argus-lp.vercel.app/privacy.html` が `200 OK` を返すことを確認

## Notes
- iOS 設定は変更していません
- `v0.4.0` タグ作成と Google Play production draft 作成はこの PR のマージ後に実施します