### PR TITLE
[codex] バージョン表示・更新確認・位置情報取得を改善

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
 
     <queries>
         <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
             <action android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
         </intent>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:upgrader/upgrader.dart';
 
 import 'app_controller.dart';
 import 'theme/app_theme.dart';
@@ -11,14 +12,27 @@ import 'ui/home_page.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final controller = await AppController.bootstrap();
-  runApp(ArgusApp(controller: controller));
+  runApp(
+    ArgusApp(
+      controller: controller,
+      upgrader: Upgrader(
+        countryCode: 'JP',
+        languageCode: 'ja',
+      ),
+    ),
+  );
 }
 // coverage:ignore-end
 
 class ArgusApp extends StatefulWidget {
-  const ArgusApp({super.key, required this.controller});
+  const ArgusApp({
+    super.key,
+    required this.controller,
+    this.upgrader,
+  });
 
   final AppController controller;
+  final Upgrader? upgrader;
 
   @override
   State<ArgusApp> createState() => _ArgusAppState();
@@ -50,12 +64,20 @@ class _ArgusAppState extends State<ArgusApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    final home = widget.upgrader == null
+        ? const HomePage()
+        : UpgradeAlert(
+            upgrader: widget.upgrader!,
+            showIgnore: false,
+            showReleaseNotes: false,
+            child: const HomePage(),
+          );
     return ChangeNotifierProvider.value(
       value: widget.controller,
       child: MaterialApp(
         title: 'Argus',
         theme: AppTheme.light(),
-        home: const HomePage(),
+        home: home,
       ),
     );
   }

--- a/lib/platform/location_service.dart
+++ b/lib/platform/location_service.dart
@@ -85,13 +85,6 @@ class LocationSettingsFactory {
       distanceFilter: 0,
     );
   }
-
-  LocationSettings buildPollSettings() {
-    return const LocationSettings(
-      accuracy: LocationAccuracy.best,
-      distanceFilter: 0,
-    );
-  }
 }
 
 // coverage:ignore-start
@@ -109,7 +102,6 @@ class GeolocatorLocationService implements LocationService {
   final StreamController<LocationFix> _controller =
       StreamController<LocationFix>.broadcast();
   StreamSubscription<Position>? _subscription;
-  Timer? _pollTimer;
 
   @override
   Stream<LocationFix> get stream => _controller.stream;
@@ -139,18 +131,11 @@ class GeolocatorLocationService implements LocationService {
       runtimePlatform: _runtimePlatform,
       interval: interval,
     );
-    final pollSettings = _settingsFactory.buildPollSettings();
-
     try {
       await _subscription?.cancel();
-      _pollTimer?.cancel();
       _subscription = Geolocator.getPositionStream(
         locationSettings: settings,
       ).listen(_emitPosition);
-      _pollTimer = Timer.periodic(interval, (_) {
-        unawaited(_pollCurrentPosition(pollSettings));
-      });
-      unawaited(_pollCurrentPosition(pollSettings));
       return const LocationServiceStartResult.started();
     } catch (e) {
       return LocationServiceStartResult(
@@ -162,8 +147,6 @@ class GeolocatorLocationService implements LocationService {
 
   @override
   Future<void> stop() async {
-    _pollTimer?.cancel();
-    _pollTimer = null;
     await _subscription?.cancel();
     _subscription = null;
   }
@@ -177,17 +160,6 @@ class GeolocatorLocationService implements LocationService {
         timestamp: position.timestamp,
       ),
     );
-  }
-
-  Future<void> _pollCurrentPosition(LocationSettings settings) async {
-    try {
-      final position = await Geolocator.getCurrentPosition(
-        locationSettings: settings,
-      );
-      _emitPosition(position);
-    } catch (_) {
-      // The stream remains active even if one explicit poll fails.
-    }
   }
 }
 // coverage:ignore-end

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
 import '../app_controller.dart';
@@ -492,6 +493,22 @@ class _SettingsPageState extends State<SettingsPage> {
                           );
                         },
                         child: const Text('ログを出力'),
+                      ),
+                      const SizedBox(height: 24),
+                      FutureBuilder<PackageInfo>(
+                        future: PackageInfo.fromPlatform(),
+                        builder: (context, snapshot) {
+                          final packageInfo = snapshot.data;
+                          final version = packageInfo == null
+                              ? '読み込み中'
+                              : '${packageInfo.version} (${packageInfo.buildNumber})';
+                          return Text(
+                            'バージョン $version',
+                            key: const Key('appVersionLabel'),
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          );
+                        },
                       ),
                     ],
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   share_plus: ^11.1.0
   gal: ^2.3.2
   package_info_plus: ^8.3.1
+  upgrader: ^13.5.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   url_launcher: ^6.3.2
   share_plus: ^11.1.0
   gal: ^2.3.2
+  package_info_plus: ^8.3.1
 
 dev_dependencies:
   flutter_test:
@@ -37,7 +38,6 @@ dev_dependencies:
 
 dependency_overrides:
   geolocator_linux: 0.2.3
-  package_info_plus: 8.3.1
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: "none"
-version: 0.4.0+1005
+version: 0.4.1+1005
 environment:
   sdk: ">=3.2.0 <4.0.0"
 

--- a/test/platform/location_service_test.dart
+++ b/test/platform/location_service_test.dart
@@ -96,18 +96,6 @@ void main() {
     expect(foreground.setOngoing, isTrue);
   });
 
-  test(
-      'LocationSettingsFactory keeps explicit polling settings platform-neutral',
-      () {
-    const factory = LocationSettingsFactory();
-
-    final settings = factory.buildPollSettings();
-
-    expect(settings, isA<LocationSettings>());
-    expect(settings.accuracy, LocationAccuracy.best);
-    expect(settings.distanceFilter, 0);
-  });
-
   test('LocationSettingsFactory builds Apple background indicator settings',
       () {
     const factory = LocationSettingsFactory();

--- a/test/ui/settings_page_test.dart
+++ b/test/ui/settings_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:argus/io/config.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
 import 'package:argus/app_controller.dart';
@@ -69,6 +70,13 @@ Future<void> _invokeSaveButton(WidgetTester tester) async {
 void main() {
   setUpAll(() async {
     await mockDefaultConfigAsset();
+    PackageInfo.setMockInitialValues(
+      appName: 'ARGUS',
+      packageName: 'com.argus.orienteering',
+      version: '0.4.0',
+      buildNumber: '1005',
+      buildSignature: '',
+    );
   });
 
   tearDown(() async {
@@ -103,6 +111,11 @@ void main() {
     expect(find.text('境界バッファ距離'), findsOneWidget);
     expect(find.text('プライバシーポリシー'), findsOneWidget);
     expect(find.textContaining('デフォルト:'), findsWidgets);
+    await _scrollUntilVisible(
+      tester,
+      find.byKey(const Key('appVersionLabel')),
+    );
+    expect(find.text('バージョン 0.4.0 (1005)'), findsOneWidget);
   });
 
   testWidgets('falls back when default config asset cannot load',

--- a/test/ui/settings_page_test.dart
+++ b/test/ui/settings_page_test.dart
@@ -73,7 +73,7 @@ void main() {
     PackageInfo.setMockInitialValues(
       appName: 'ARGUS',
       packageName: 'com.argus.orienteering',
-      version: '0.4.0',
+      version: '0.4.1',
       buildNumber: '1005',
       buildSignature: '',
     );
@@ -115,7 +115,7 @@ void main() {
       tester,
       find.byKey(const Key('appVersionLabel')),
     );
-    expect(find.text('バージョン 0.4.0 (1005)'), findsOneWidget);
+    expect(find.text('バージョン 0.4.1 (1005)'), findsOneWidget);
   });
 
   testWidgets('falls back when default config asset cannot load',


### PR DESCRIPTION
## 概要

Issue #75、#73、#61をまとめて対応します。アプリ内で現在のバージョンを確認できるようにし、起動時にストアの公開バージョンを確認して更新ページへ誘導します。また、位置情報取得をストリームへ一本化します。

Closes #75
Closes #73
Closes #61

## 変更点

| 対象 | 変更内容 |
| --- | --- |
| バージョン表示 | 設定画面に実行中アプリのバージョン名とビルド番号を表示 |
| 更新確認 | 起動時にGoogle Play / App Storeの公開版を確認し、新版がある場合は更新ダイアログを表示 |
| ストア遷移 | 更新操作から各プラットフォームのストア詳細ページを開く |
| 位置情報 | 常時pollingを廃止し、foreground対応のgetPositionStreamへ一本化 |
| テスト | バージョン表示テストを追加し、polling前提のテストを整理 |

## 検証

- `flutter analyze`
- `flutter test`（269件成功）
- `test/ui/settings_page_test.dart`
- `test/platform/location_service_test.dart`
- `test/main_test.dart`

## レビューしてほしいリスク

- Playストアの内部・クローズドテスト版は公開ページに出ないため、更新検出はproduction公開版が対象です。
- 位置情報をstreamのみにしたため、Android実機で画面OFF・バックグラウンド時に長時間継続することを確認してください。
- iOSはApp Store公開後、Bundle IDからストア情報を取得できることを確認してください。