### PR TITLE
[codex] AGZ圧縮とQRファイル名保持を実装

### DIFF
--- a/docs/geojson_to_qr.md
+++ b/docs/geojson_to_qr.md
@@ -1,6 +1,6 @@
 # GeoJSON ↔ QRコード（完全オフライン）機能 要件定義書
 
-最終更新: 2025-11-06 / 作成者: ChatGPT
+最終更新: 2026-06-17
 
 ---
 
@@ -12,7 +12,7 @@
 ## 1. 用語定義
 - **GeoJSON**: IETF RFC 7946に準拠したJSON形式の地理空間データ。
 - **QRテキスト**: QRコードに格納するUTF-8文字列。`<scheme>:<payload>`形式。
-- **スキーム（scheme）**: 符号化・圧縮方式の識別子。現行実装は `gjz1`。
+- **スキーム（scheme）**: 符号化・圧縮方式の識別子。標準は `agz1`、後方互換形式は `gjz1`。
 - **完全オフライン**: 生成・復元の全工程がネットワーク接続なしで完結すること。
 
 ---
@@ -52,35 +52,39 @@
 
 ## 6. 機能要件（FR）
 
-### FR-1: GeoJSON最小化
-- 入力GeoJSONをパースし、`json.dumps(..., separators=(",", ":"))`相当で最小化する。
-- 目的: 圧縮効率・ハッシュ安定性の向上。
+### FR-1: ARGUS Polygon差分化
+- `agz1` はFeatureCollection、Feature 1個、Polygon 1個、外周リングのみを対象とする。
+- 座標を小数6桁の整数へ変換し、先頭点以外を前点との差分として保存する。propertiesは保持しない。
+- 元ファイル名はパスを除去して `.geojson` に正規化し、UTF-8のBase64URLとして本文へ格納する。
 
 ### FR-2: スキーム別エンコード
-- **`gjz1:`**: `gzip`圧縮 → Base64（URL-safe, `=`パディング省略）でエンコード。
+- **`agz1:`**: `a3:<scale>:<filename>:<coordinates>` → gzip → Base64URL（`=`パディング省略）でエンコード。
+- **`gjz1:`**: 最小化GeoJSON → gzip → Base64URLでエンコードする後方互換形式。
 - **`<scheme>:<payload>`** に連結し、ASCII互換の連続文字列とする。
 
 ### FR-3: 整合性オプション
-- ハッシュ付与を選択可。形式: `...#<sha256_hex>`
-- 対象は**圧縮前の最小化GeoJSON**。
-- 復元時に一致検証（オプション）。
+- `agz1` はgzip CRCとQR誤り訂正を使用し、SHA-256接尾辞を付けない。
+- `gjz1` は圧縮前の最小化GeoJSONに対するSHA-256を `#<sha256_hex>` として付与・検証できる。
 
 ### FR-4: 容量超過時の扱い
 - 単一QRに収まらない場合、分割は行わず `E_PAYLOAD_TOO_LARGE` を返す。
 - 利用者にはGeoJSONの簡略化、対象エリアの分割、またはファイル読み込みを案内する。
 
 ### FR-5: 復号処理
-- 入力が`gjz1:`なら直接復号。
+- `agz1:` と `gjz1:` を識別して復号する。
+- `agz1` はPolygon GeoJSONと埋め込み元ファイル名を復元する。
 - Base64URLはパディングを自動補完。
 - 圧縮展開に失敗した場合、適切なエラーを返却。
 
 ### FR-6: GeoJSON妥当性検査
-- 復元後、`type`が`FeatureCollection`/`Feature`/`GeometryCollection`/`Point`/`LineString`/`Polygon`/`MultiPoint`/`MultiLineString`/`MultiPolygon`のいずれかであることを確認。
+- `agz1` エンコード時は単一Feature、単一Polygon、穴なし、4点以上、閉じたリングであることを確認する。
+- `gjz1` 復元後は従来どおりGeoJSONのtypeを検証する。
 
 ### FR-7: QR画像生成
 - 誤り訂正レベル: 既定**Q**、選択肢にL/M/Q/H。
 - バージョン自動。サイズ制約超過時は容量超過エラーを返す。
 - 画像フォーマット: PNG（透過背景可）。
+- 保存・共有ファイル名: 入力が `hoge.geojson` の場合は `QR_hoge.png`。
 - 物理設計指針: モジュール≥0.3mm、余白（クワイエットゾーン）既定4モジュール。
 
 ### FR-8: 入出力I/O
@@ -133,11 +137,18 @@
 | E_DECOMPRESS_FAILED  | 圧縮展開失敗   | gzipエラー        | スキーム誤り/データ破損           |
 | E_INVALID_GEOJSON    | JSON妥当性NG   | `type`欠落        | 入力源見直し/再作成               |
 | E_PAYLOAD_TOO_LARGE  | 単一QR超過     | Version上限超     | 簡略化/ファイル読込               |
+| E_BASE64_DECODE_FAILED | AGZ外装復号失敗 | Base64URL破損 | 再スキャン/再生成 |
+| E_GZIP_DECOMPRESS_FAILED | AGZ展開失敗 | gzip破損 | 再スキャン/再生成 |
+| E_INVALID_DIFF_TEXT / E_INVALID_SCALE | a3本文不正 | 版・scale不正 | 対応版で再生成 |
+| E_INVALID_COORDINATE | 座標不正 | 数値以外の座標 | 元GeoJSONを修正 |
+| E_TOO_FEW_POINTS / E_POLYGON_NOT_CLOSED | Polygon不正 | 点不足・非閉鎖 | Polygonを修正 |
+| E_UNSUPPORTED_GEOMETRY | AGZ対象外 | 複数Feature・穴・MultiPolygon | 対象を単一Polygonへ変換 |
+| E_INVALID_FILENAME | ファイル名不正 | 空・長すぎる名前 | 元ファイル名を修正 |
 
 ---
 
 ## 9. 容量と印刷設計ガイド
-- 目安：最小化GeoJSON 100点 ≈ 4KB（素のJSON）。`gjz1`圧縮後 ≈ 1–2KB。
+- `agz1` はGeoJSONの構造名とpropertiesを除去するため、対象Polygonでは `gjz1` より短いQRテキストになる。
 - 単一QRでの実運用は **2〜3KB** 程度までが安全域（誤り訂正Q, 品質良）。
 - それ以上はGeoJSONの簡略化、対象エリアの分割、またはファイル読み込みを推奨。
 - 物理印刷：A6でも可だが、読み取り距離を考慮してサイズ・コントラスト確保。
@@ -146,9 +157,9 @@
 
 ## 10. I/O仕様（ファイル/テキスト）
 - **入力（エンコード）**: `.geojson`/`.json` or 標準入力（UTF-8）
-- **出力（エンコード）**: `out.png` + `qr_texts.txt`
-- **入力（デコード）**: `gjz1:`の行（ファイル/標準入力）
-- **出力（デコード）**: `restored.geojson`（UTF-8）
+- **出力（エンコード）**: `QR_<入力ファイルのstem>.png`
+- **入力（デコード）**: `agz1:` または `gjz1:` のQRテキスト
+- **出力（デコード）**: `agz1` は埋め込み名、`gjz1` は一時名のGeoJSON（UTF-8）
 
 ---
 
@@ -160,19 +171,19 @@
 ---
 
 ## 12. 品質保証（テスト計画）
-- **単体**: 最小化、圧縮/展開、Base64URL、ハッシュ、QR生成の各関数。
-- **結合**: `geojson → gjz1 → QR → gjz1 → geojson`往復同値性。
-- **異常系**: スキーム不正、Base破損、圧縮形式不一致、容量超過。
+- **単体**: a3差分化、圧縮/展開、Base64URL、ファイル名、gjz1ハッシュ、QR生成。
+- **結合**: `geojson → agz1 → QR → agz1 → geojson` と既存 `gjz1` の往復同値性。
+- **異常系**: スキーム、Base64、gzip、a3、scale、座標、非閉鎖Polygon、非対応Geometry、ファイル名、容量超過。
 - **負荷**: 1KB/2KB/4KB/8KB/16KBの代表パターン。
 - **デバイス**: 主要解像度/画面輝度/印刷品質で読み取り試験。
 
 ---
 
 ## 13. 受け入れ基準（Acceptance Criteria）
-- AC-1: 既知のGeoJSON（サンプル3件以上）で往復同値性が成立する。
+- AC-1: 小数6桁以内の対象Polygonで座標と元ファイル名の往復同値性が成立する。
 - AC-2: 2KB, 4KB, 8KBケースで単一QR生成または容量超過エラーが規定通りに返る。
 - AC-3: 容量超過時に`E_PAYLOAD_TOO_LARGE`を返す。
-- AC-4: `--hash/--verify-hash`相当の整合性検証が成功/失敗で判定できる。
+- AC-4: 既存 `gjz1` のハッシュ検証が引き続き成功/失敗で判定できる。
 - AC-5: 誤り訂正Qで名刺サイズ相当の印刷から実機読み取りが可能。
 
 ---
@@ -191,7 +202,7 @@
 ---
 
 ## 16. 変更管理（MoSCoW）
-- **Must**: `gjz1`単一、ハッシュ任意、復元、QR生成、エラーハンドリング。
+- **Must**: `agz1`生成・復元・ファイル名保持、`gjz1`読取互換、QR生成、エラーハンドリング。
 - **Should**: 大容量GeoJSON向けの案内表示、進行表示。
 - **Could**: 署名/暗号化、TopoJSON/Polyline前処理、GUIランチャ。
 - **Won't (v1)**: オンライン配布、短縮URL、サーバ連携。
@@ -206,7 +217,8 @@
 ---
 
 ## 18. 付録（参考フォーマット）
-- 単一: `gjz1:<base64url_no_pad_of_gzip(minified_json)>[#<sha256>]`
+- 標準: `agz1:<base64url_no_pad_of_gzip(a3:<scale>:<filename>:<coordinates>)>`
+- 互換: `gjz1:<base64url_no_pad_of_gzip(minified_json)>[#<sha256>]`
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,8 +19,8 @@
 
 - **初回起動**: GeoJSON は自動ロードしない。状態は `waitGeoJson` で開始し、ユーザーがファイルまたは QR から読み込む。
 - **ファイルピッカー**: ユーザは FloatingActionButton（「Load GeoJSON」ラベル）またはファイルピッカーで `.geojson` / `.json` を再ロード可能。
-- **QRコード読み込み**: ユーザは FloatingActionButton（「Read QR code」ラベル）でQRコードをスキャンし、GeoJSONを読み込むことが可能。QRコードは `gjz1:` スキームで始まる必要がある。読み込んだGeoJSONは一時ファイルとして保存され、アプリ終了時に自動削除される。
-- **ファイル名処理**: 読み込んだファイル名は `.geojson` 拡張子に正規化され、UI に表示される。QRコードから読み込んだ場合は `temp_geojson_<timestamp>.geojson` という名前で一時ファイルとして保存される。
+- **QRコード読み込み**: ユーザは FloatingActionButton（「Read QR code」ラベル）でQRコードをスキャンし、GeoJSONを読み込むことが可能。QRコードは `agz1:` または互換用の `gjz1:` スキームで始まる必要がある。読み込んだGeoJSONは一時ファイルとして保存され、アプリ終了時に自動削除される。
+- **ファイル名処理**: 読み込んだファイル名は `.geojson` 拡張子に正規化され、UI に表示される。`agz1` では埋め込まれた元ファイル名を表示し、一時ファイルの実体は `temp_geojson_<timestamp>.geojson` として管理する。
 - **エラー処理**: 読み込み失敗はエラーバナーとログ（レベル ERROR）で通知。`FormatException` とその他の例外を区別して表示。QRコードの形式が無効な場合やデコードに失敗した場合も適切にエラーを表示する。
 
 ### 1.2 位置情報ストリーム
@@ -510,21 +510,22 @@ stateDiagram-v2
 
 ### 5.1.1 エンコード処理
 
-- **最小化**: GeoJSON文字列から不要な空白（改行、スペース、タブ）を除去し、構造を保持。
+- **標準形式**: 単一Feature・単一Polygon・外周リングをscale 6の整数差分列へ変換し、元ファイル名とともに `a3:<scale>:<filename>:<coordinates>` へ格納。
 - **圧縮**: gzip圧縮（level=9）を使用。外部CLIは不要。
 - **エンコード**: Base64URLエンコード（パディングなし、URL-safe文字）。
-- **ハッシュ**: 最小化されたGeoJSONのSHA256ハッシュを計算（16進数文字列）。
+- **ハッシュ**: `agz1` には付与しない。互換用`gjz1`では最小化されたGeoJSONのSHA256ハッシュを使用可能。
 - **QRテキスト形式**: 
-  - 単一QR: `gjz1:<base64url_payload>#<hash>`
+  - 標準: `agz1:<base64url(gzip(a3本文))>`
+  - 互換: `gjz1:<base64url_payload>[#<hash>]`
 - **容量制限**: QRテキスト長が`maxQrTextLength`（デフォルト2500文字）を超える場合、`PayloadTooLargeException`を返す。
-- **QR画像生成**: PNG形式でQRコード画像を生成（オプション、デフォルト有効）。
+- **QR画像生成**: PNG形式でQRコード画像を生成（オプション、デフォルト有効）。画像名は `QR_<GeoJSONのstem>.png`。
 
 ### 5.1.2 デコード処理
 
-- **スキーム検証**: QRテキストが`gjz1:`で始まることを確認。
+- **スキーム検証**: QRテキストが`agz1:`または`gjz1:`で始まることを確認。
 - **Base64URLデコード**: パディングを自動補完してデコード。
 - **gzip展開**: Dart標準の`GZipCodec`で展開。
-- **ハッシュ検証**: 復元されたGeoJSONのハッシュを計算し、QRテキストに含まれるハッシュと比較（`verifyHash=true`の場合）。
+- **ハッシュ検証**: `gjz1`では復元されたGeoJSONのハッシュをQRテキストと比較（`verifyHash=true`の場合）。
 - **GeoJSON検証**: 復元された文字列が有効なGeoJSONであることを確認（`type`フィールドの存在）。
 
 ### 5.1.3 エラーハンドリング
@@ -536,11 +537,15 @@ stateDiagram-v2
 - **HashMismatchException**: ハッシュが一致しない場合。
 - **UnsupportedSchemeException**: サポートされていないスキームの場合。
 - **PayloadTooLargeException**: QRコードの容量を超える場合。
+- **Base64DecodeFailedException / GzipDecompressFailedException**: `agz1`外装の破損。
+- **InvalidDiffTextException / InvalidScaleException / InvalidCoordinateException**: `a3`本文の破損。
+- **TooFewPointsException / PolygonNotClosedException / UnsupportedGeometryException**: AGZ対象外のPolygon構造。
+- **InvalidFileNameException**: 埋め込みファイル名が空、不正、または長すぎる場合。
 
 ### 5.1.4 一時ファイル管理
 
 - **保存場所**: `getTemporaryDirectory()`で取得した一時ディレクトリ。
-- **ファイル名**: `temp_geojson_<timestamp>.geojson`（`timestamp`はミリ秒単位のエポック時刻）。
+- **ファイル名**: 実体は `temp_geojson_<timestamp>.geojson`（`timestamp`はミリ秒単位のエポック時刻）。`agz1`の表示名は埋め込まれた元ファイル名。
 - **クリーンアップ**: アプリが完全終了時（`AppLifecycleState.detached`）に自動削除。新しいQRコードを読み込む際も既存の一時ファイルを削除。
 
 ---

--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -352,14 +352,16 @@ class AppController extends ChangeNotifier {
     try {
       // QRテキストが対応スキームで始まることを確認
       if (!isSupportedGeoJsonQrText(qrText)) {
-        _lastErrorMessage = 'Invalid QR code format. Expected gjz1: scheme.';
+        _lastErrorMessage =
+            'Invalid QR code format. Expected gjz1: or agz1: scheme.';
         _logError('APP', _lastErrorMessage!);
         notifyListeners();
         return false;
       }
 
       // QRテキストからGeoJSONを復元
-      final restoredGeoJson = await compute(_decodeGeoJsonQrText, qrText);
+      final decoded = await compute(_decodeGeoJsonQrText, qrText);
+      final restoredGeoJson = decoded.geoJson;
 
       // 一時ディレクトリに保存
       final tempDir = await getTemporaryDirectory();
@@ -377,7 +379,7 @@ class AppController extends ChangeNotifier {
       final model = GeoModel.fromGeoJson(restoredGeoJson);
 
       _geoModel = model;
-      _geoJsonFileName = 'temp_geojson_$timestamp.geojson';
+      _geoJsonFileName = decoded.fileName ?? 'temp_geojson_$timestamp.geojson';
       _areaIndex = AreaIndex.build(model.polygons);
       stateMachine.updateGeometry(_geoModel, _areaIndex);
 
@@ -820,8 +822,8 @@ class AppController extends ChangeNotifier {
   }
 }
 
-Future<String> _decodeGeoJsonQrText(String qrText) {
-  return decodeGeoJson(
+Future<DecodedGeoJson> _decodeGeoJsonQrText(String qrText) {
+  return decodeGeoJsonWithMetadata(
     GeoJsonQrDecodeInput(
       qrTexts: [qrText],
       verifyHash: true,

--- a/lib/qr/geojson_qr_codec.dart
+++ b/lib/qr/geojson_qr_codec.dart
@@ -209,6 +209,9 @@ extension GeoJsonQrSchemeName on GeoJsonQrScheme {
 
 /// GeoJSON文字列をQRテキスト(とPNG)へ変換する。
 Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
+  final agzDiffText = input.scheme == GeoJsonQrScheme.agz1
+      ? _geoJsonToAgzDiffText(input.geoJson, input.sourceFileName)
+      : null;
   final minifyResult = minifyGeoJson(input.geoJson);
   final minimizedBytes =
       Uint8List.fromList(utf8.encode(minifyResult.minimized));
@@ -216,7 +219,7 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
     GeoJsonQrScheme.gjz1 => minimizedBytes,
     GeoJsonQrScheme.agz1 => Uint8List.fromList(
         utf8.encode(
-          _geoJsonToAgzDiffText(input.geoJson, input.sourceFileName),
+          agzDiffText!,
         ),
       ),
   };
@@ -504,6 +507,9 @@ QrPayload _parseSinglePayload(GeoJsonQrScheme scheme, String text) {
     throw DecodeFailedException('Empty $prefix payload');
   }
   final split = _splitPayloadAndHash(payloadWithHash);
+  if (scheme == GeoJsonQrScheme.agz1 && split.hashHex != null) {
+    throw DecodeFailedException('agz1 does not support a hash suffix');
+  }
   return QrPayload(scheme, split.payload, split.hashHex);
 }
 
@@ -542,12 +548,7 @@ const int _agzScale = 6;
 
 String _geoJsonToAgzDiffText(String geoJson, String? sourceFileName) {
   final fileName = _normalizeGeoJsonFileName(sourceFileName);
-  dynamic decoded;
-  try {
-    decoded = jsonDecode(geoJson);
-  } on FormatException catch (e) {
-    throw GeoJsonValidationException('Invalid JSON format', e);
-  }
+  final dynamic decoded = jsonDecode(geoJson);
   if (decoded is! Map<String, dynamic> ||
       decoded['type'] != 'FeatureCollection') {
     throw UnsupportedGeometryException(

--- a/lib/qr/geojson_qr_codec.dart
+++ b/lib/qr/geojson_qr_codec.dart
@@ -10,6 +10,7 @@ import 'package:qr/qr.dart';
 class GeoJsonQrEncodeInput {
   const GeoJsonQrEncodeInput({
     required this.geoJson,
+    this.sourceFileName,
     this.scheme = GeoJsonQrScheme.gjz1,
     this.enableHash = true,
     this.maxQrTextLength = 2500,
@@ -22,6 +23,7 @@ class GeoJsonQrEncodeInput {
         assert(quietZoneModules >= 0, 'quietZoneModules must be >= 0');
 
   final String geoJson;
+  final String? sourceFileName;
   final GeoJsonQrScheme scheme;
   final bool enableHash;
   final int maxQrTextLength;
@@ -60,6 +62,14 @@ class GeoJsonQrBundle {
   final GeoJsonInfo info;
 }
 
+/// QRから復元したGeoJSONと、ペイロードに含まれる元ファイル名。
+class DecodedGeoJson {
+  const DecodedGeoJson({required this.geoJson, this.fileName});
+
+  final String geoJson;
+  final String? fileName;
+}
+
 /// GeoJSONの概要情報。
 class GeoJsonInfo {
   const GeoJsonInfo({required this.type, this.featureCount});
@@ -93,11 +103,59 @@ class CompressFailedException extends GeoJsonQrException {
 class DecompressFailedException extends GeoJsonQrException {
   DecompressFailedException(String message, [Object? cause])
       : super('E_DECOMPRESS_FAILED', message, cause);
+
+  DecompressFailedException.withCode(super.code, super.message, [super.cause]);
 }
 
 class DecodeFailedException extends GeoJsonQrException {
   DecodeFailedException(String message, [Object? cause])
       : super('E_DECODE_FAILED', message, cause);
+
+  DecodeFailedException.withCode(super.code, super.message, [super.cause]);
+}
+
+class Base64DecodeFailedException extends DecodeFailedException {
+  Base64DecodeFailedException(String message, [Object? cause])
+      : super.withCode('E_BASE64_DECODE_FAILED', message, cause);
+}
+
+class GzipDecompressFailedException extends DecompressFailedException {
+  GzipDecompressFailedException(String message, [Object? cause])
+      : super.withCode('E_GZIP_DECOMPRESS_FAILED', message, cause);
+}
+
+class InvalidDiffTextException extends GeoJsonQrException {
+  InvalidDiffTextException(String message, [Object? cause])
+      : super('E_INVALID_DIFF_TEXT', message, cause);
+}
+
+class InvalidScaleException extends GeoJsonQrException {
+  InvalidScaleException(String message, [Object? cause])
+      : super('E_INVALID_SCALE', message, cause);
+}
+
+class InvalidCoordinateException extends GeoJsonQrException {
+  InvalidCoordinateException(String message, [Object? cause])
+      : super('E_INVALID_COORDINATE', message, cause);
+}
+
+class TooFewPointsException extends GeoJsonQrException {
+  TooFewPointsException(String message) : super('E_TOO_FEW_POINTS', message);
+}
+
+class PolygonNotClosedException extends GeoJsonQrException {
+  PolygonNotClosedException(String message)
+      : super('E_POLYGON_NOT_CLOSED', message);
+}
+
+class UnsupportedGeometryException extends GeoJsonQrException {
+  UnsupportedGeometryException(String message)
+      : super('E_UNSUPPORTED_GEOMETRY', message);
+}
+
+class InvalidFileNameException extends GeoJsonQrException {
+  InvalidFileNameException(String message, [Object? cause])
+      : super('E_INVALID_FILENAME', message, cause);
 }
 
 class UnsupportedSchemeException extends GeoJsonQrException {
@@ -131,6 +189,9 @@ enum QrErrorCorrectionLevel {
 enum GeoJsonQrScheme {
   /// gzip圧縮。Dart標準ライブラリのみで生成/復元できる。
   gjz1,
+
+  /// ARGUSの単一Polygonに特化した差分圧縮形式。
+  agz1,
 }
 
 extension GeoJsonQrSchemeName on GeoJsonQrScheme {
@@ -138,6 +199,8 @@ extension GeoJsonQrSchemeName on GeoJsonQrScheme {
     switch (this) {
       case GeoJsonQrScheme.gjz1:
         return 'gjz1';
+      case GeoJsonQrScheme.agz1:
+        return 'agz1';
     }
   }
 
@@ -149,10 +212,20 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
   final minifyResult = minifyGeoJson(input.geoJson);
   final minimizedBytes =
       Uint8List.fromList(utf8.encode(minifyResult.minimized));
+  final bytesToCompress = switch (input.scheme) {
+    GeoJsonQrScheme.gjz1 => minimizedBytes,
+    GeoJsonQrScheme.agz1 => Uint8List.fromList(
+        utf8.encode(
+          _geoJsonToAgzDiffText(input.geoJson, input.sourceFileName),
+        ),
+      ),
+  };
   final compressedBytes =
-      await _compressForScheme(input.scheme, minimizedBytes);
+      await _compressForScheme(input.scheme, bytesToCompress);
   final payload = base64UrlEncodeNoPad(compressedBytes);
-  final hashHex = input.enableHash ? computeSha256Hex(minimizedBytes) : null;
+  final hashHex = input.scheme == GeoJsonQrScheme.gjz1 && input.enableHash
+      ? computeSha256Hex(minimizedBytes)
+      : null;
 
   var qrTexts =
       _buildQrTexts(input.scheme, payload, hashHex, input.maxQrTextLength);
@@ -188,11 +261,19 @@ Future<GeoJsonQrBundle> encodeGeoJson(GeoJsonQrEncodeInput input) async {
 
 bool isSupportedGeoJsonQrText(String text) {
   final normalized = text.trim();
-  return normalized.startsWith('gjz1:');
+  return normalized.startsWith('gjz1:') || normalized.startsWith('agz1:');
 }
 
 /// QRテキストからGeoJSON文字列を復元する。
 Future<String> decodeGeoJson(GeoJsonQrDecodeInput input) async {
+  final decoded = await decodeGeoJsonWithMetadata(input);
+  return decoded.geoJson;
+}
+
+/// QRテキストからGeoJSON文字列と埋め込みファイル名を復元する。
+Future<DecodedGeoJson> decodeGeoJsonWithMetadata(
+  GeoJsonQrDecodeInput input,
+) async {
   final normalized = input.qrTexts
       .map((e) => e.trim())
       .where((element) => element.isNotEmpty)
@@ -203,20 +284,48 @@ Future<String> decodeGeoJson(GeoJsonQrDecodeInput input) async {
   }
 
   final payload = _parseQrPayload(normalized);
-  final compressedBytes = base64UrlDecodeNoPad(payload.payload);
-  final minimizedBytes = _decompressForScheme(payload.scheme, compressedBytes);
-  final minimized = utf8.decode(minimizedBytes);
+  late final Uint8List compressedBytes;
+  try {
+    compressedBytes = base64UrlDecodeNoPad(payload.payload);
+  } on DecodeFailedException catch (e) {
+    if (payload.scheme == GeoJsonQrScheme.agz1) {
+      throw Base64DecodeFailedException(e.message, e.cause);
+    }
+    rethrow;
+  }
+
+  late final Uint8List decompressedBytes;
+  try {
+    decompressedBytes = _decompressForScheme(payload.scheme, compressedBytes);
+  } on DecompressFailedException catch (e) {
+    if (payload.scheme == GeoJsonQrScheme.agz1) {
+      throw GzipDecompressFailedException(e.message, e.cause);
+    }
+    rethrow;
+  }
+
+  if (payload.scheme == GeoJsonQrScheme.agz1) {
+    try {
+      return _agzDiffTextToGeoJson(utf8.decode(decompressedBytes));
+    } on GeoJsonQrException {
+      rethrow;
+    } on FormatException catch (e) {
+      throw InvalidDiffTextException('AGZ diff text is not valid UTF-8', e);
+    }
+  }
+
+  final minimized = utf8.decode(decompressedBytes);
 
   validateGeoJsonStructure(jsonDecode(minimized));
 
   if (input.verifyHash && payload.hashHex != null) {
-    final currentHash = computeSha256Hex(minimizedBytes);
+    final currentHash = computeSha256Hex(decompressedBytes);
     if (!_constantTimeEquals(payload.hashHex!, currentHash)) {
       throw HashMismatchException('Hash mismatch detected');
     }
   }
 
-  return minimized;
+  return DecodedGeoJson(geoJson: minimized);
 }
 
 /// GeoJSON最小化と検証。
@@ -327,6 +436,7 @@ Future<Uint8List> _compressForScheme(
 ) {
   switch (scheme) {
     case GeoJsonQrScheme.gjz1:
+    case GeoJsonQrScheme.agz1:
       return Future.value(gzipCompress(bytes));
   }
 }
@@ -334,6 +444,7 @@ Future<Uint8List> _compressForScheme(
 Uint8List _decompressForScheme(GeoJsonQrScheme scheme, Uint8List bytes) {
   switch (scheme) {
     case GeoJsonQrScheme.gjz1:
+    case GeoJsonQrScheme.agz1:
       return gzipDecompress(bytes);
   }
 }
@@ -370,6 +481,9 @@ QrPayload _parseQrPayload(List<String> texts) {
     final text = texts.first;
     if (text.startsWith('gjz1:')) {
       return _parseSinglePayload(GeoJsonQrScheme.gjz1, text);
+    }
+    if (text.startsWith('agz1:')) {
+      return _parseSinglePayload(GeoJsonQrScheme.agz1, text);
     }
   }
 
@@ -422,6 +536,231 @@ class QrPayload {
   final GeoJsonQrScheme scheme;
   final String payload;
   final String? hashHex;
+}
+
+const int _agzScale = 6;
+
+String _geoJsonToAgzDiffText(String geoJson, String? sourceFileName) {
+  final fileName = _normalizeGeoJsonFileName(sourceFileName);
+  dynamic decoded;
+  try {
+    decoded = jsonDecode(geoJson);
+  } on FormatException catch (e) {
+    throw GeoJsonValidationException('Invalid JSON format', e);
+  }
+  if (decoded is! Map<String, dynamic> ||
+      decoded['type'] != 'FeatureCollection') {
+    throw UnsupportedGeometryException(
+      'agz1 requires a FeatureCollection',
+    );
+  }
+  final features = decoded['features'];
+  if (features is! List || features.length != 1) {
+    throw UnsupportedGeometryException(
+      'agz1 requires exactly one Feature',
+    );
+  }
+  final feature = features.single;
+  if (feature is! Map<String, dynamic>) {
+    throw UnsupportedGeometryException('Feature must be an object');
+  }
+  final geometry = feature['geometry'];
+  if (geometry is! Map<String, dynamic> || geometry['type'] != 'Polygon') {
+    throw UnsupportedGeometryException('agz1 supports only Polygon geometry');
+  }
+  final coordinates = geometry['coordinates'];
+  if (coordinates is! List || coordinates.length != 1) {
+    throw UnsupportedGeometryException(
+      'agz1 supports exactly one exterior ring and no holes',
+    );
+  }
+  final ring = coordinates.single;
+  if (ring is! List) {
+    throw InvalidCoordinateException('Polygon ring must be a list');
+  }
+  if (ring.length < 4) {
+    throw TooFewPointsException(
+      'Polygon must contain at least four points including closure',
+    );
+  }
+
+  final points = ring.map(_readCoordinate).toList(growable: false);
+  if (points.first.lon != points.last.lon ||
+      points.first.lat != points.last.lat) {
+    throw PolygonNotClosedException(
+      'Polygon final point must match its first point',
+    );
+  }
+
+  const factor = 1000000;
+  final integerPoints = points
+      .map(
+        (point) => _IntegerCoordinate(
+          (point.lon * factor).round(),
+          (point.lat * factor).round(),
+        ),
+      )
+      .toList(growable: false);
+  final first = integerPoints.first;
+  final deltas = <String>[];
+  var previous = first;
+  for (final point in integerPoints.skip(1)) {
+    deltas.add('${point.lon - previous.lon},${point.lat - previous.lat}');
+    previous = point;
+  }
+
+  final fileNameToken = base64UrlEncodeNoPad(
+    Uint8List.fromList(utf8.encode(fileName)),
+  );
+  return 'a3:$_agzScale:$fileNameToken:'
+      '${first.lon},${first.lat}|${deltas.join(';')}';
+}
+
+DecodedGeoJson _agzDiffTextToGeoJson(String diffText) {
+  final fields = diffText.split(':');
+  if (fields.length != 4 || fields.first != 'a3') {
+    throw InvalidDiffTextException(
+      'Expected a3:<scale>:<filename>:<coordinates>',
+    );
+  }
+
+  final scale = int.tryParse(fields[1]);
+  if (scale == null || scale < 0 || scale > 9) {
+    throw InvalidScaleException('AGZ scale must be an integer from 0 to 9');
+  }
+
+  final fileName = _decodeAgzFileName(fields[2]);
+  final coordinateSections = fields[3].split('|');
+  if (coordinateSections.length != 2 || coordinateSections[1].isEmpty) {
+    throw InvalidDiffTextException(
+      'AGZ coordinates must contain an absolute point and deltas',
+    );
+  }
+
+  final first = _parseIntegerCoordinate(coordinateSections[0]);
+  final points = <_IntegerCoordinate>[first];
+  var previous = first;
+  for (final deltaText in coordinateSections[1].split(';')) {
+    final delta = _parseIntegerCoordinate(deltaText);
+    final current = _IntegerCoordinate(
+      previous.lon + delta.lon,
+      previous.lat + delta.lat,
+    );
+    points.add(current);
+    previous = current;
+  }
+  if (points.length < 4) {
+    throw TooFewPointsException(
+      'Polygon must contain at least four points including closure',
+    );
+  }
+  if (points.first.lon != points.last.lon ||
+      points.first.lat != points.last.lat) {
+    throw PolygonNotClosedException(
+      'Polygon final point must match its first point',
+    );
+  }
+
+  var factor = 1.0;
+  for (var i = 0; i < scale; i++) {
+    factor *= 10;
+  }
+  final ring = points
+      .map((point) => <double>[point.lon / factor, point.lat / factor])
+      .toList(growable: false);
+  final geoJson = jsonEncode({
+    'type': 'FeatureCollection',
+    'features': [
+      {
+        'type': 'Feature',
+        'properties': <String, dynamic>{},
+        'geometry': {
+          'type': 'Polygon',
+          'coordinates': [ring],
+        },
+      },
+    ],
+  });
+  return DecodedGeoJson(geoJson: geoJson, fileName: fileName);
+}
+
+String _decodeAgzFileName(String token) {
+  if (token.isEmpty) {
+    throw InvalidFileNameException('AGZ filename is empty');
+  }
+  try {
+    final decoded = utf8.decode(base64UrlDecodeNoPad(token));
+    return _normalizeGeoJsonFileName(decoded);
+  } on InvalidFileNameException {
+    rethrow;
+  } on Object catch (e) {
+    throw InvalidFileNameException('Invalid AGZ filename', e);
+  }
+}
+
+String _normalizeGeoJsonFileName(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    throw InvalidFileNameException('A source filename is required for agz1');
+  }
+  var name = value.trim().replaceAll('\\', '/').split('/').last;
+  final queryIndex = name.indexOf(RegExp(r'[?#]'));
+  if (queryIndex >= 0) {
+    name = name.substring(0, queryIndex);
+  }
+  final dotIndex = name.lastIndexOf('.');
+  final stem = (dotIndex > 0 ? name.substring(0, dotIndex) : name).trim();
+  if (stem.isEmpty || RegExp(r'[\x00-\x1f\x7f]').hasMatch(stem)) {
+    throw InvalidFileNameException('AGZ filename is invalid');
+  }
+  final normalized = '$stem.geojson';
+  if (utf8.encode(normalized).length > 255) {
+    throw InvalidFileNameException('AGZ filename is too long');
+  }
+  return normalized;
+}
+
+_Coordinate _readCoordinate(dynamic value) {
+  if (value is! List || value.length < 2) {
+    throw InvalidCoordinateException('Coordinate must contain lon and lat');
+  }
+  final lon = value[0];
+  final lat = value[1];
+  if (lon is! num || lat is! num) {
+    throw InvalidCoordinateException('Coordinate values must be numbers');
+  }
+  final lonValue = lon.toDouble();
+  final latValue = lat.toDouble();
+  if (!lonValue.isFinite || !latValue.isFinite) {
+    throw InvalidCoordinateException('Coordinate values must be finite');
+  }
+  return _Coordinate(lonValue, latValue);
+}
+
+_IntegerCoordinate _parseIntegerCoordinate(String value) {
+  final parts = value.split(',');
+  if (parts.length != 2) {
+    throw InvalidCoordinateException('Coordinate must contain two integers');
+  }
+  final lon = int.tryParse(parts[0]);
+  final lat = int.tryParse(parts[1]);
+  if (lon == null || lat == null) {
+    throw InvalidCoordinateException('Coordinate values must be integers');
+  }
+  return _IntegerCoordinate(lon, lat);
+}
+
+class _Coordinate {
+  const _Coordinate(this.lon, this.lat);
+
+  final double lon;
+  final double lat;
+}
+
+class _IntegerCoordinate {
+  const _IntegerCoordinate(this.lon, this.lat);
+
+  final int lon;
+  final int lat;
 }
 
 Uint8List generateQrPng(

--- a/lib/ui/qr_generator_page.dart
+++ b/lib/ui/qr_generator_page.dart
@@ -68,11 +68,13 @@ class _QrGeneratorPageState extends State<QrGeneratorPage> {
       }
 
       final rawGeoJson = await selected.readAsString();
+      final sourceFileName = _displayFileName(selected);
       final bundle = await widget.encoder(
         GeoJsonQrEncodeInput(
           geoJson: rawGeoJson,
-          scheme: GeoJsonQrScheme.gjz1,
-          enableHash: true,
+          sourceFileName: sourceFileName,
+          scheme: GeoJsonQrScheme.agz1,
+          enableHash: false,
           maxQrTextLength: 2500,
           eccLevel: QrErrorCorrectionLevel.quartile,
           generatePng: true,
@@ -96,7 +98,7 @@ class _QrGeneratorPageState extends State<QrGeneratorPage> {
       setState(() {
         _isGenerating = false;
         _generatedQr = _GeneratedQr(
-          fileName: _displayFileName(selected),
+          fileName: sourceFileName,
           imageBytes: bundle.pngImages.single,
           info: bundle.info,
           schemeLabel: _schemeLabel(bundle.qrTexts.single),
@@ -144,7 +146,7 @@ class _QrGeneratorPageState extends State<QrGeneratorPage> {
     try {
       await widget.gallerySaver(
         generated.imageBytes,
-        generated.outputBaseName,
+        generated.outputFileName,
       );
       if (!mounted) {
         return;
@@ -180,7 +182,7 @@ class _QrGeneratorPageState extends State<QrGeneratorPage> {
     try {
       await widget.shareHandler(
         generated.imageBytes,
-        '${generated.outputBaseName}.png',
+        generated.outputFileName,
         context,
       );
     } catch (e) {
@@ -418,12 +420,13 @@ class _GeneratedQr {
   final int minimizedBytes;
   final int qrTextBytes;
 
-  String get outputBaseName {
+  String get outputFileName {
     final withoutExtension = path.basenameWithoutExtension(fileName);
-    final normalized =
-        withoutExtension.replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '_');
+    final normalized = withoutExtension
+        .replaceAll(RegExp(r'[<>:"/\\|?*\x00-\x1f]+'), '_')
+        .replaceAll(RegExp(r'[. ]+$'), '');
     final safeName = normalized.isEmpty ? 'geojson' : normalized;
-    return 'argus_qr_$safeName';
+    return 'QR_$safeName.png';
   }
 }
 
@@ -443,7 +446,10 @@ Future<void> _saveQrToGallery(Uint8List bytes, String name) async {
   if (!hasAccess) {
     throw Exception('写真へのアクセスが許可されていません。');
   }
-  await Gal.putImageBytes(bytes, name: name);
+  // galのAndroid実装は検出した拡張子を自動付与するため、二重拡張子を避ける。
+  final galleryName =
+      Platform.isAndroid ? path.basenameWithoutExtension(name) : name;
+  await Gal.putImageBytes(bytes, name: galleryName);
 }
 
 Future<void> _shareQrImage(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: argus
 description: Geo-fence monitoring app per spec.md
 publish_to: "none"
-version: 0.4.1+1005
+version: 0.5.0+1005
 environment:
   sdk: ">=3.2.0 <4.0.0"
 

--- a/spec.md
+++ b/spec.md
@@ -85,7 +85,7 @@
 ### 5.8 UI
 - Home (`home_page.dart`): 大型ステータス円で状態表示（INNER/NEAR/OUTER 等、色付き）。`waitStart` ではタップで監視開始。GeoJSON ファイル名と GPS 精度を常時表示。OUTER（または Developer mode）で距離/方位ナビ表示。最新 5 件のアプリ内ログをカードで閲覧。エラーは Snackbar。
 - Settings (`settings_page.dart`): 設定フォーム（Inner buffer, GPS 精度閾値, Leave confirm サンプル/秒, Alarm 音量）。Developer mode トグル。ログ JSON エクスポート（メモリ上の `EventLogger` 内容をその場表示）。
-- QR Scanner (`qr_scanner_page.dart`): `mobile_scanner` で `gjz1` スキーム QR を読み取り、`AppController.reloadGeoJsonFromQr` へ連携。処理中オーバーレイとエラーバナーを表示。
+- QR Scanner (`qr_scanner_page.dart`): `mobile_scanner` で `agz1` / `gjz1` スキーム QR を読み取り、`AppController.reloadGeoJsonFromQr` へ連携。処理中オーバーレイとエラーバナーを表示。
 - テーマ: Material3、Seed color Blue。文言は日本語中心で一部英語残り。
 
 ## 6. データ/設定リファレンス

--- a/spec.md
+++ b/spec.md
@@ -12,7 +12,7 @@
 
 ## 2. ユースケース価値
 - 端末完結の監視（ネット不要）で通信遮断時も動作。
-- QR コード経由で GeoJSON を安全に配布（gzip 圧縮＋Base64URL＋SHA-256 ハッシュ検証）。
+- QR コード経由で GeoJSON を安全に配布（ARGUS専用差分圧縮または汎用gzip圧縮）。
 - 「離脱確定までの猶予」(サンプル数 + 経過秒数) を設定でき、GPS ノイズによる誤検知を抑制。
 - 離脱時は無音の高重要度通知＋アラーム音＋連続バイブで確実に気付かせる。
 - Developer mode でエリア内でも距離・方位を確認でき、デバッグ／捜索補助に使える。
@@ -34,7 +34,7 @@
 2) 権限要求: 通知権限は警告を見逃さないための setup 対象。監視開始のブロック条件は位置サービス有効 + Always 位置権限で、PermissionCoordinator が foreground から background の順に確認・要求する。拒否/永久拒否時は app/location settings への導線を出す。  
 3) GeoJSON 取込:
    - ファイル: `FileManager.pickGeoJsonFile()` で `.geojson/.json/.bin` を選択しパース→`GeoModel`→`AreaIndex` 構築。ファイル名を `.geojson` 拡張子に正規化して保持。
-   - QR: `gjz1:` テキストを復元→gzip 伸長→構造バリデーション→一時ファイル保存（次回起動で消去）。  
+   - QR: `agz1:` / `gjz1:` テキストを復元→gzip 伸長→構造バリデーション→一時ファイル保存（次回起動で消去）。`agz1` は元ファイル名も復元する。
    ロード成功後の状態は `waitStart`、`navigationEnabled` は false にリセット、アラーム停止。
 4) 監視開始: `startMonitoring()` で Geolocator ストリーム購読開始。`sampleIntervalS['fast']`（デフォルト 3 秒）間隔・距離フィルタ 0m・`LocationAccuracy.best`。
 5) 評価ループ: 各 `LocationFix` を `StateMachine.evaluate()` に通し、UI/ログ/通知に反映。OUTER 確定時に通知＋アラーム。再入時に停止通知。
@@ -48,10 +48,10 @@
 - 新規ロード時は監視を一時停止し、AreaIndex も再構築。
 
 ### 5.2 QR コーデック（ライブラリ）
-- エンコード: GeoJSON を jsonEncode → gzip(level=9) → Base64URL（= 無パディング）→ `gjz1:<payload>[#hash]`。単一QRに収まらない場合は `PayloadTooLargeException`。オプションで PNG 生成（`qr` + `image` パッケージ）。
-- ハッシュ: デフォルトで SHA-256 を付与し、デコード時に検証 (`verifyHash=true`)。不一致なら `HashMismatchException`。
-- デコード: `gjz1` 以外は拒否。gzip 伸長後に GeoJSON 構造チェックを行い、無効なら `GeoJsonValidationException`。
-- 一時ファイル: QR 取込時のみ `temp_geojson_<timestamp>.geojson` を作成。次回起動(detached)または再読込時に削除。
+- 標準エンコード: 単一Feature・単一Polygonの外周座標をscale 6の差分列へ変換し、元ファイル名とともに `a3` 本文へ格納する。gzip(level=9) → Base64URL（= 無パディング）→ `agz1:<payload>` とし、画像名は `QR_<元名>.png`。
+- 互換形式: `gjz1:<payload>[#hash]` の生成APIと読み込みを維持する。`gjz1` のSHA-256検証も従来どおり行う。
+- デコード: `agz1` はGeoJSONと埋め込みファイル名を復元し、`gjz1` はGeoJSONのみ復元する。
+- 一時ファイル: QR取込時の実体は `temp_geojson_<timestamp>.geojson` として安全に管理し、表示名には `agz1` 内の元ファイル名を使う。次回起動(detached)または再読込時に削除する。
 
 ### 5.3 権限
 - 通知: 警告を見逃さないための setup 対象。拒否時は app settings への導線を表示するが、監視開始ブロック条件そのものではない。

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -867,7 +867,11 @@ void main() {
 
       // QRコードを生成
       final bundle = await encodeGeoJson(
-        const GeoJsonQrEncodeInput(geoJson: _squareGeoJson),
+        const GeoJsonQrEncodeInput(
+          geoJson: _squareGeoJson,
+          sourceFileName: 'hoge.geojson',
+          scheme: GeoJsonQrScheme.agz1,
+        ),
       );
       final qrText = bundle.qrTexts.first;
 
@@ -880,8 +884,7 @@ void main() {
         // 成功した場合のアサーション
         expect(controller.geoJsonLoaded, isTrue);
         expect(controller.geoJsonFileName, isNotNull);
-        expect(controller.geoJsonFileName, contains('temp_geojson_'));
-        expect(controller.geoJsonFileName, endsWith('.geojson'));
+        expect(controller.geoJsonFileName, 'hoge.geojson');
         expect(controller.snapshot.notes, 'GeoJSON loaded from QR code');
         expect(locationService.stopped, isTrue);
       } catch (e) {

--- a/test/qr/geojson_qr_codec_test.dart
+++ b/test/qr/geojson_qr_codec_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:argus/qr/geojson_qr_codec.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -68,6 +69,163 @@ void main() {
 
   test('gjz1 helper exposes wire name', () {
     expect(GeoJsonQrScheme.gjz1.wireName, 'gjz1');
+  });
+
+  test('agz1 round trip preserves six-digit coordinates and filename',
+      () async {
+    final bundle = await encodeGeoJson(
+      const GeoJsonQrEncodeInput(
+        geoJson: _agzGeoJson,
+        sourceFileName: r'C:\courses\hoge.json',
+        scheme: GeoJsonQrScheme.agz1,
+        generatePng: false,
+      ),
+    );
+
+    expect(bundle.qrTexts.single, startsWith('agz1:'));
+    expect(bundle.hashHex, isNull);
+    final payload = bundle.qrTexts.single.substring('agz1:'.length);
+    final diffText = utf8.decode(gzipDecompress(base64UrlDecodeNoPad(payload)));
+    expect(diffText, startsWith('a3:6:'));
+
+    final restored = await decodeGeoJsonWithMetadata(
+      GeoJsonQrDecodeInput(qrTexts: bundle.qrTexts),
+    );
+    expect(restored.fileName, 'hoge.geojson');
+    final decoded = jsonDecode(restored.geoJson) as Map<String, dynamic>;
+    final ring = ((decoded['features'] as List).single['geometry']
+            ['coordinates'] as List)
+        .single as List;
+    expect(
+      ring,
+      const [
+        [140.123456, 35.123456],
+        [140.223456, 35.123456],
+        [140.223456, 35.223456],
+        [140.123456, 35.123456],
+      ],
+    );
+  });
+
+  test('agz1 is smaller than the sample GeoJSON and is recognized', () async {
+    final bundle = await encodeGeoJson(
+      GeoJsonQrEncodeInput(
+        geoJson: sampleGeoJson,
+        sourceFileName: 'map.geojson',
+        scheme: GeoJsonQrScheme.agz1,
+        generatePng: false,
+      ),
+    );
+
+    expect(bundle.qrTexts.single.length,
+        lessThan(utf8.encode(sampleGeoJson).length));
+    expect(isSupportedGeoJsonQrText(bundle.qrTexts.single), isTrue);
+    expect(isSupportedGeoJsonQrText('gjz1:test'), isTrue);
+  });
+
+  test('agz1 rejects unsupported geometry shapes', () async {
+    Future<void> expectUnsupported(String geoJson) async {
+      await expectLater(
+        encodeGeoJson(
+          GeoJsonQrEncodeInput(
+            geoJson: geoJson,
+            sourceFileName: 'hoge.geojson',
+            scheme: GeoJsonQrScheme.agz1,
+            generatePng: false,
+          ),
+        ),
+        throwsA(isA<UnsupportedGeometryException>()),
+      );
+    }
+
+    await expectUnsupported(
+        _agzGeoJson.replaceFirst('"Polygon"', '"MultiPolygon"'));
+    await expectUnsupported(_featureCollectionWithFeatures('[{},{}]'));
+    await expectUnsupported(
+      _agzGeoJson.replaceFirst(
+        '[[[140.123456',
+        '[[[0,0],[1,0],[0,0]],[[140.123456',
+      ),
+    );
+  });
+
+  test('agz1 rejects missing filename, too few points, and open polygon',
+      () async {
+    await expectLater(
+      encodeGeoJson(
+        const GeoJsonQrEncodeInput(
+          geoJson: _agzGeoJson,
+          scheme: GeoJsonQrScheme.agz1,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<InvalidFileNameException>()),
+    );
+    await expectLater(
+      encodeGeoJson(
+        const GeoJsonQrEncodeInput(
+          geoJson: _tooFewPointsGeoJson,
+          sourceFileName: 'hoge.geojson',
+          scheme: GeoJsonQrScheme.agz1,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<TooFewPointsException>()),
+    );
+    await expectLater(
+      encodeGeoJson(
+        const GeoJsonQrEncodeInput(
+          geoJson: _openPolygonGeoJson,
+          sourceFileName: 'hoge.geojson',
+          scheme: GeoJsonQrScheme.agz1,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<PolygonNotClosedException>()),
+    );
+  });
+
+  test('agz1 reports corrupt payload categories', () async {
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        const GeoJsonQrDecodeInput(qrTexts: ['agz1:@@@@']),
+      ),
+      throwsA(isA<Base64DecodeFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: ['agz1:${base64UrlEncodeNoPad(utf8.encode('not gzip'))}'],
+        ),
+      ),
+      throwsA(isA<GzipDecompressFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(qrTexts: [_agzQrText('a2:6:x:1,1|1,1')]),
+      ),
+      throwsA(isA<InvalidDiffTextException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+            qrTexts: [_agzQrText('a3:x:aG9nZS5nZW9qc29u:1,1|1,1;1,1;-2,-2')]),
+      ),
+      throwsA(isA<InvalidScaleException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+            qrTexts: [_agzQrText('a3:6:aG9nZS5nZW9qc29u:1,x|1,1;1,1;-2,-2')]),
+      ),
+      throwsA(isA<InvalidCoordinateException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(qrTexts: [_agzQrText('a3:6::1,1|1,1;1,1;-2,-2')]),
+      ),
+      throwsA(isA<InvalidFileNameException>()),
+    );
   });
 
   test('encode rejects payloads that exceed max text length', () async {
@@ -265,4 +423,27 @@ void main() {
       throwsA(isA<PayloadTooLargeException>()),
     );
   });
+}
+
+const _agzGeoJson = '{"type":"FeatureCollection","features":[{"type":"Feature",'
+    '"properties":{"ignored":true},"geometry":{"type":"Polygon",'
+    '"coordinates":[[[140.123456,35.123456],[140.223456,35.123456],'
+    '[140.223456,35.223456],[140.123456,35.123456]]]}}]}';
+
+const _tooFewPointsGeoJson =
+    '{"type":"FeatureCollection","features":[{"type":"Feature",'
+    '"properties":{},"geometry":{"type":"Polygon",'
+    '"coordinates":[[[0,0],[1,0],[0,0]]]}}]}';
+
+const _openPolygonGeoJson =
+    '{"type":"FeatureCollection","features":[{"type":"Feature",'
+    '"properties":{},"geometry":{"type":"Polygon",'
+    '"coordinates":[[[0,0],[1,0],[1,1],[0,1]]]}}]}';
+
+String _featureCollectionWithFeatures(String features) =>
+    '{"type":"FeatureCollection","features":$features}';
+
+String _agzQrText(String diffText) {
+  final compressed = gzipCompress(Uint8List.fromList(utf8.encode(diffText)));
+  return 'agz1:${base64UrlEncodeNoPad(compressed)}';
 }

--- a/test/qr/geojson_qr_codec_test.dart
+++ b/test/qr/geojson_qr_codec_test.dart
@@ -76,7 +76,7 @@ void main() {
     final bundle = await encodeGeoJson(
       const GeoJsonQrEncodeInput(
         geoJson: _agzGeoJson,
-        sourceFileName: r'C:\courses\hoge.json',
+        sourceFileName: r'C:\courses\hoge.json?download=1',
         scheme: GeoJsonQrScheme.agz1,
         generatePng: false,
       ),
@@ -225,6 +225,146 @@ void main() {
         GeoJsonQrDecodeInput(qrTexts: [_agzQrText('a3:6::1,1|1,1;1,1;-2,-2')]),
       ),
       throwsA(isA<InvalidFileNameException>()),
+    );
+  });
+
+  test('agz1 rejects hash suffix and invalid UTF-8 diff text', () async {
+    final valid = _agzQrText(
+      'a3:6:aG9nZS5nZW9qc29u:1,1|1,0;0,1;-1,-1',
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(qrTexts: ['$valid#${'a' * 64}']),
+      ),
+      throwsA(isA<DecodeFailedException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(qrTexts: [
+          _agzQrBytes([0xff])
+        ]),
+      ),
+      throwsA(isA<InvalidDiffTextException>()),
+    );
+  });
+
+  test('agz1 rejects malformed feature, ring, and coordinate structures',
+      () async {
+    Future<void> expectAgzError(String geoJson, Matcher matcher) {
+      return expectLater(
+        encodeGeoJson(
+          GeoJsonQrEncodeInput(
+            geoJson: geoJson,
+            sourceFileName: 'hoge.geojson',
+            scheme: GeoJsonQrScheme.agz1,
+            generatePng: false,
+          ),
+        ),
+        throwsA(matcher),
+      );
+    }
+
+    await expectAgzError(
+      '{"type":"Polygon","coordinates":[]}',
+      isA<UnsupportedGeometryException>(),
+    );
+    await expectAgzError(
+      _featureCollectionWithFeatures('[null]'),
+      isA<UnsupportedGeometryException>(),
+    );
+    await expectAgzError(
+      _polygonGeoJson('"not-a-ring"'),
+      isA<InvalidCoordinateException>(),
+    );
+    await expectAgzError(
+      _polygonGeoJson('[[0],[1,0],[1,1],[0]]'),
+      isA<InvalidCoordinateException>(),
+    );
+    await expectAgzError(
+      _polygonGeoJson('[[0,0],["x",0],[1,1],[0,0]]'),
+      isA<InvalidCoordinateException>(),
+    );
+  });
+
+  test('agz1 rejects malformed decoded polygons and filenames', () async {
+    const name = 'aG9nZS5nZW9qc29u';
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(qrTexts: [_agzQrText('a3:6:$name:1,1')]),
+      ),
+      throwsA(isA<InvalidDiffTextException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: [_agzQrText('a3:6:$name:1,1|1,0;-1,0')],
+        ),
+      ),
+      throwsA(isA<TooFewPointsException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: [_agzQrText('a3:6:$name:1,1|1,0;0,1;0,1')],
+        ),
+      ),
+      throwsA(isA<PolygonNotClosedException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: [_agzQrText('a3:6:$name:1,1|1;0,1;-1,-1')],
+        ),
+      ),
+      throwsA(isA<InvalidCoordinateException>()),
+    );
+    final invalidName = base64UrlEncodeNoPad(
+      Uint8List.fromList(utf8.encode('ba\nd.geojson')),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: [
+            _agzQrText('a3:6:$invalidName:1,1|1,0;0,1;-1,-1'),
+          ],
+        ),
+      ),
+      throwsA(isA<InvalidFileNameException>()),
+    );
+    await expectLater(
+      decodeGeoJsonWithMetadata(
+        GeoJsonQrDecodeInput(
+          qrTexts: [
+            _agzQrText('a3:6:@@@@:1,1|1,0;0,1;-1,-1'),
+          ],
+        ),
+      ),
+      throwsA(isA<InvalidFileNameException>()),
+    );
+    await expectLater(
+      encodeGeoJson(
+        GeoJsonQrEncodeInput(
+          geoJson: _agzGeoJson,
+          sourceFileName: '${'x' * 256}.geojson',
+          scheme: GeoJsonQrScheme.agz1,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<InvalidFileNameException>()),
+    );
+    await expectLater(
+      encodeGeoJson(
+        const GeoJsonQrEncodeInput(
+          geoJson: '{"type":"FeatureCollection","features":['
+              '{"type":"Feature","properties":{},"geometry":{'
+              '"type":"Polygon","coordinates":['
+              '[[0,0],[1e999,0],[1,1],[0,0]]]}}]}',
+          sourceFileName: 'hoge.geojson',
+          scheme: GeoJsonQrScheme.agz1,
+          generatePng: false,
+        ),
+      ),
+      throwsA(isA<InvalidCoordinateException>()),
     );
   });
 
@@ -443,7 +583,17 @@ const _openPolygonGeoJson =
 String _featureCollectionWithFeatures(String features) =>
     '{"type":"FeatureCollection","features":$features}';
 
+String _polygonGeoJson(String ring) =>
+    '{"type":"FeatureCollection","features":[{"type":"Feature",'
+    '"properties":{},"geometry":{"type":"Polygon",'
+    '"coordinates":[$ring]}}]}';
+
 String _agzQrText(String diffText) {
   final compressed = gzipCompress(Uint8List.fromList(utf8.encode(diffText)));
+  return 'agz1:${base64UrlEncodeNoPad(compressed)}';
+}
+
+String _agzQrBytes(List<int> bytes) {
+  final compressed = gzipCompress(Uint8List.fromList(bytes));
   return 'agz1:${base64UrlEncodeNoPad(compressed)}';
 }

--- a/test/ui/qr_generator_page_test.dart
+++ b/test/ui/qr_generator_page_test.dart
@@ -21,7 +21,10 @@ void main() {
       (tester) async {
     var saved = false;
     var shared = false;
+    String? savedName;
+    String? sharedName;
     GeoJsonQrScheme? requestedScheme;
+    String? requestedFileName;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -34,8 +37,9 @@ void main() {
           ),
           encoder: (input) async {
             requestedScheme = input.scheme;
+            requestedFileName = input.sourceFileName;
             return GeoJsonQrBundle(
-              qrTexts: const ['gjz1:test'],
+              qrTexts: const ['agz1:test'],
               pngImages: [qrPng],
               minimizedGeoJson: '{"type":"FeatureCollection","features":[]}',
               hashHex: 'a' * 64,
@@ -47,9 +51,11 @@ void main() {
           },
           gallerySaver: (bytes, name) async {
             saved = true;
+            savedName = name;
           },
           shareHandler: (bytes, fileName, context) async {
             shared = true;
+            sharedName = fileName;
           },
         ),
       ),
@@ -63,20 +69,23 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('generated_qr_image')), findsOneWidget);
-    expect(requestedScheme, GeoJsonQrScheme.gjz1);
+    expect(requestedScheme, GeoJsonQrScheme.agz1);
+    expect(requestedFileName, 'course.geojson');
     expect(find.text('保存'), findsOneWidget);
     expect(find.text('共有'), findsOneWidget);
     expect(find.text('course.geojson'), findsOneWidget);
-    expect(find.text('gjz1'), findsOneWidget);
+    expect(find.text('agz1'), findsOneWidget);
 
     await tester.tap(find.text('保存'));
     await tester.pumpAndSettle();
     expect(saved, isTrue);
+    expect(savedName, 'QR_course.png');
     expect(find.text('写真に保存しました'), findsOneWidget);
 
     await tester.tap(find.text('共有'));
     await tester.pumpAndSettle();
     expect(shared, isTrue);
+    expect(sharedName, 'QR_course.png');
   });
 
   testWidgets('rejects encoder output without a single PNG image',

--- a/test/ui/qr_scanner_page_test.dart
+++ b/test/ui/qr_scanner_page_test.dart
@@ -240,7 +240,7 @@ void main() {
       expect(find.text('GeoJSON QR コードではありません。'), findsNothing);
     });
 
-    testWidgets('valid QR displays controller error when load fails',
+    testWidgets('valid agz1 QR is accepted by scanner',
         (WidgetTester tester) async {
       final controller = _RecordingQrController()
         ..loadedResult = false
@@ -258,7 +258,7 @@ void main() {
                   child: ElevatedButton(
                     onPressed: () => onDetect(
                       const BarcodeCapture(
-                        barcodes: [Barcode(rawValue: 'gjz1:test')],
+                        barcodes: [Barcode(rawValue: 'agz1:test')],
                       ),
                     ),
                     child: const Text('Emit Valid'),
@@ -274,7 +274,7 @@ void main() {
       await tester.tap(find.text('Emit Valid'));
       await tester.pumpAndSettle();
 
-      expect(controller.scannedTexts, ['gjz1:test']);
+      expect(controller.scannedTexts, ['agz1:test']);
       expect(find.text('GeoJSON の読込に失敗しました。'), findsOneWidget);
     });
 


### PR DESCRIPTION
## 概要

Issue #74 のARGUS専用圧縮形式 `agz1` と、Issue #57 のQR経由でのファイル名保持を実装します。

Closes #74
Closes #57

## 変更点

| 項目 | 変更内容 |
|---|---|
| AGZ形式 | `agz1:<base64url(gzip(a3本文))>` を追加し、単一Feature・単一Polygonの外周座標をscale 6の差分列で圧縮 |
| ファイル名 | 元GeoJSON名をa3本文へ埋め込み、QR読込後も `hoge.geojson` として表示 |
| QR画像名 | `hoge.geojson` から生成する保存・共有名を `QR_hoge.png` に変更 |
| 互換性 | 既存の `gjz1` 読込・SHA-256検証を維持 |
| エラー処理 | Base64、gzip、a3、scale、座標、Polygon、ファイル名の異常を専用エラーとして分類 |
| テスト・仕様書 | codec、controller、生成画面のテストと仕様書を更新 |

## レビューしてほしいリスク

- `agz1` は単一Feature・単一Polygon・穴なしに限定し、それ以外は明示的に拒否します。
- 座標は小数6桁へ丸めるため、それより細かい精度は保持されません。
- `a3` のファイル名フィールドと、Android/iOSでの `QR_<name>.png` 命名を確認してください。
- 実ファイルは安全な一時名で保存し、埋め込み名は表示用途に分離しています。

## 検証

- `flutter analyze`
- `flutter test`（274件成功）
- Android 16実機へrelease APKをインストール済み
